### PR TITLE
Add -C flag to change the current working directory

### DIFF
--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -82,6 +82,12 @@ func addApply(topLevel *cobra.Command) {
   ko apply -f config -- --namespace=foo --kubeconfig=cfg.yaml
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if bo.WorkingDirectory != "" {
+				if err := os.Chdir(bo.WorkingDirectory); err != nil {
+					return fmt.Errorf("chdir: %w", err)
+				}
+			}
+
 			if !isKubectlAvailable() {
 				return errors.New("error: kubectl is not available. kubectl must be installed to use ko apply")
 			}

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -67,6 +67,12 @@ func addCreate(topLevel *cobra.Command) {
   ko apply -f config -- --namespace=foo --kubeconfig=cfg.yaml
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if bo.WorkingDirectory != "" {
+				if err := os.Chdir(bo.WorkingDirectory); err != nil {
+					return fmt.Errorf("chdir: %w", err)
+				}
+			}
+
 			if !isKubectlAvailable() {
 				return errors.New("error: kubectl is not available. kubectl must be installed to use ko create")
 			}

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -44,7 +44,7 @@ type BuildOptions struct {
 	// BaseImageOverrides stores base image overrides for import paths.
 	BaseImageOverrides map[string]string
 
-	// WorkingDirectory allows for setting the working directory for invocations of the `go` tool.
+	// WorkingDirectory allows for setting the working directory before any actions are taken.
 	// Empty string means the current working directory.
 	WorkingDirectory string
 
@@ -80,15 +80,15 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
+	cmd.Flags().StringVarP(&bo.WorkingDirectory, "directory", "C", ".",
+		"Change to this directory before performing any operations.")
 	bo.Trimpath = true
 }
 
 // LoadConfig reads build configuration from defaults, environment variables, and the `.ko.yaml` config file.
 func (bo *BuildOptions) LoadConfig() error {
 	v := viper.New()
-	if bo.WorkingDirectory == "" {
-		bo.WorkingDirectory = "."
-	}
+
 	// If omitted, use this base image.
 	v.SetDefault("defaultBaseImage", configDefaultBaseImage)
 	const configName = ".ko"

--- a/pkg/commands/resolve.go
+++ b/pkg/commands/resolve.go
@@ -56,8 +56,14 @@ func addResolve(topLevel *cobra.Command) {
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-
 			bo.InsecureRegistry = po.InsecureRegistry
+
+			if bo.WorkingDirectory != "" {
+				if err := os.Chdir(bo.WorkingDirectory); err != nil {
+					return fmt.Errorf("chdir: %w", err)
+				}
+			}
+
 			builder, err := makeBuilder(ctx, bo)
 			if err != nil {
 				return fmt.Errorf("error creating builder: %w", err)

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -51,6 +51,12 @@ func addRun(topLevel *cobra.Command) {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
+			if bo.WorkingDirectory != "" {
+				if err := os.Chdir(bo.WorkingDirectory); err != nil {
+					return fmt.Errorf("chdir: %w", err)
+				}
+			}
+
 			// Args after -- are for kubectl, so only consider importPaths before it.
 			importPaths := args
 			dashes := cmd.Flags().ArgsLenAtDash()


### PR DESCRIPTION
This PR adds the following flag:

```
  -C, --directory string               Change to this directory before performing any operations. (default ".")
```

To the following commands:

* `apply`
* `build`
* `create`
* `resolve`
* `run`


I had initially planned on leaving the default as "", but wavered when I saw what was already being done here:

https://github.com/google/ko/blob/ea93812481f6b58e2cfe2346a8abde24198c3dc4/pkg/commands/options/build.go#L90

Please let me know if you would prefer the flag default to be "", as it would save a syscall, but require the previous logic in `build`.

Fixes #617

Signed-off-by: Thomas Stromberg <t+github@chainguard.dev>