### PR TITLE
Support `ko build ./...`

### DIFF
--- a/.github/workflows/modules-integration-test.yaml
+++ b/.github/workflows/modules-integration-test.yaml
@@ -8,6 +8,7 @@ jobs:
   test:
     name: Module Tests
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.16.x, 1.17.x]
     runs-on: 'ubuntu-latest'

--- a/main.go
+++ b/main.go
@@ -29,6 +29,6 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 	if err := commands.Root.ExecuteContext(ctx); err != nil {
-		log.Fatal("error during command execution:", err)
+		log.Fatal("error during command execution: ", err)
 	}
 }

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/google/ko/pkg/commands/options"
 	"github.com/spf13/cobra"
@@ -65,7 +66,7 @@ func addBuild(topLevel *cobra.Command) {
 			}
 			ctx := cmd.Context()
 
-			importpaths, err := importPaths(args)
+			importpaths, err := importPaths(bo.WorkingDirectory, args)
 			if err != nil {
 				return fmt.Errorf("resolving import paths: %w", err)
 			}
@@ -98,8 +99,12 @@ func addBuild(topLevel *cobra.Command) {
 // importPaths resolves a list of importpath strings that may contain wildcards
 // like "./cmd/..." or "./...", and returns the 'package main' packages matched
 // by those importpaths.
-func importPaths(args []string) ([]string, error) {
-	ps, err := packages.Load(&packages.Config{}, args...)
+func importPaths(dir string, args []string) ([]string, error) {
+	dir = filepath.Clean(dir)
+	if dir == "." {
+		dir = ""
+	}
+	ps, err := packages.Load(&packages.Config{Dir: dir, Mode: packages.NeedName}, args...)
 	if err != nil {
 		return nil, fmt.Errorf("loading packages: %w", err)
 	}

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -109,7 +109,7 @@ func importPaths(args []string) ([]string, error) {
 			out = append(out, p.String())
 		}
 	}
-	if len(importpaths) == 0 {
+	if len(out) == 0 {
 		return nil, errors.New("no package main packages matched")
 	}
 	return out, nil

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -89,6 +89,9 @@ func addBuild(topLevel *cobra.Command) {
 			for k := range uniq {
 				importpaths = append(importpaths, k)
 			}
+			if len(importpaths) == 0 {
+				return errors.New("no package main packages matched")
+			}
 			// TODO: sort?
 
 			bo.InsecureRegistry = po.InsecureRegistry


### PR DESCRIPTION
This changes `ko build` to interpret an importpath string that ends in
"/..." by running `go list` and parsing its output to find `package
main`s matched by that wildcard.

Since `ko build` already supports passing multiple paths, this
additively collects uniq matched importpaths, so this works, and
produces three images for the three `package main`s in this repo:

```
ko build ./... ./cmd/... ./
```

Matched paths are still checked if they're `package main`, so this
doesn't work:

```
ko build ./... ./pkg/build
```

(because the explicit `pkg/build` isn't `package main`)

This also doesn't work, because the wildcard importpath doesn't match any `package main`s:

```
ko build ./pkg/...
```

This _does_ work, because the set of wildcard importpaths taken together matches at least one `package main`:

```
ko build ./cmd/... ./pkg/...
```

Fixes https://github.com/google/ko/issues/643
Fixes https://github.com/google/ko/issues/273