### PR TITLE
Add Cobra flag helpers for file options

### DIFF
--- a/pkg/commands/options/filestuff.go
+++ b/pkg/commands/options/filestuff.go
@@ -35,21 +35,15 @@ func AddFileArg(cmd *cobra.Command, fo *FilenameOptions) {
 	cmd.Flags().BoolVarP(&fo.Recursive, "recursive", "R", fo.Recursive,
 		"Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
 
-	err := cmd.MarkFlagFilename("filename", "yaml", "yml", "json")
-
-	if err != nil {
+	if err := cmd.MarkFlagFilename("filename", "yaml", "yml", "json"); err != nil {
 		log.Fatalf("Error marking filename flag as Cobra's filename: %v", err)
 	}
 
-	err = cmd.MarkFlagDirname("filename")
-
-	if err != nil {
+	if err := cmd.MarkFlagDirname("filename"); err != nil {
 		log.Fatalf("Error marking filename flag as Cobra's Dirname: %v", err)
 	}
 
-	err = cmd.MarkFlagRequired("filename")
-
-	if err != nil {
+	if err := cmd.MarkFlagRequired("filename"); err != nil {
 		log.Fatalf("Error marking filename flag as required: %v", err)
 	}
 }

--- a/pkg/commands/options/filestuff.go
+++ b/pkg/commands/options/filestuff.go
@@ -34,6 +34,24 @@ func AddFileArg(cmd *cobra.Command, fo *FilenameOptions) {
 		"Filename, directory, or URL to files to use to create the resource")
 	cmd.Flags().BoolVarP(&fo.Recursive, "recursive", "R", fo.Recursive,
 		"Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
+
+	err := cmd.MarkFlagFilename("filename", "yaml", "yml", "json")
+
+	if err != nil {
+		log.Fatalf("Error marking filename flag as Cobra's filename: %v", err)
+	}
+
+	err = cmd.MarkFlagDirname("filename")
+
+	if err != nil {
+		log.Fatalf("Error marking filename flag as Cobra's Dirname: %v", err)
+	}
+
+	err = cmd.MarkFlagRequired("filename")
+
+	if err != nil {
+		log.Fatalf("Error marking filename flag as required: %v", err)
+	}
 }
 
 // Based heavily on pkg/kubectl


### PR DESCRIPTION
- Marked -f flag as a filename or a directory for better completion.
- Marked it as required for every command that requires this flag.

Fixes https://github.com/google/ko/issues/541