### PR TITLE
Handle KO_DOCKER_REPO=ko.local/repo and --bare correctly

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -168,10 +168,17 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 	innerPublisher, err := func() (publish.Interface, error) {
 		repoName := po.DockerRepo
 		namer := options.MakeNamer(po)
+		// Default LocalDomain if unset.
 		if po.LocalDomain == "" {
 			po.LocalDomain = publish.LocalDomain
 		}
-		if strings.HasPrefix(repoName, po.LocalDomain) || po.Local {
+		// If repoName is unset with --local, default it to the local domain.
+		if po.Local && repoName == "" {
+			repoName = po.LocalDomain
+		}
+		// When in doubt, if repoName is under the local domain, default to --local.
+		po.Local = strings.HasPrefix(repoName, po.LocalDomain)
+		if po.Local {
 			// TODO(jonjohnsonjr): I'm assuming that nobody will
 			// use local with other publishers, but that might
 			// not be true.

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -168,10 +168,16 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 	innerPublisher, err := func() (publish.Interface, error) {
 		repoName := po.DockerRepo
 		namer := options.MakeNamer(po)
-		if strings.HasPrefix(repoName, publish.LocalDomain) || po.Local {
+		if po.LocalDomain == "" {
+			po.LocalDomain = publish.LocalDomain
+		}
+		if strings.HasPrefix(repoName, po.LocalDomain) || po.Local {
 			// TODO(jonjohnsonjr): I'm assuming that nobody will
 			// use local with other publishers, but that might
 			// not be true.
+			if po.Bare {
+				po.LocalDomain = repoName
+			}
 			return publish.NewDaemon(namer, po.Tags,
 				publish.WithDockerClient(po.DockerClient),
 				publish.WithLocalDomain(po.LocalDomain),

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -175,9 +175,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 			// TODO(jonjohnsonjr): I'm assuming that nobody will
 			// use local with other publishers, but that might
 			// not be true.
-			if po.Bare {
-				po.LocalDomain = repoName
-			}
+			po.LocalDomain = repoName
 			return publish.NewDaemon(namer, po.Tags,
 				publish.WithDockerClient(po.DockerClient),
 				publish.WithLocalDomain(po.LocalDomain),

--- a/pkg/commands/resolver_test.go
+++ b/pkg/commands/resolver_test.go
@@ -279,6 +279,15 @@ func TestNewPublisherCanPublish(t *testing.T) {
 			shouldError: true,
 			wantError:   errImageLoad,
 		},
+		{
+			description:   "bare with local domain and repo",
+			wantImageName: strings.ToLower(fmt.Sprintf("%s/foo", dockerRepo)),
+			po: &options.PublishOptions{
+				DockerRepo: dockerRepo + "/foo",
+				Local:      true,
+				Bare:       true,
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/ko-build/ko/issues/807

cc @developer-guy 

See comments in https://github.com/ko-build/ko/issues/807#issuecomment-1243695345 -- uniformly setting `base: po.LocalDomain` in `NewDaemon` was fine when we assumed/required that `KO_DOCKER_REPO=ko.local` would only be used without a repo, but we've since changed that assumption/requirement.

```
$ KO_DOCKER_REPO=ko.local/foo go run ./ build ./test --bare
...
ko.local/foo:3a28632fcb886b7a4c78be8cd36c34ec47e83f71ff55353e5602873400dca564
```

Note that this also handles `ko.local/foo` for other namers:

```
$ KO_DOCKER_REPO=ko.local/foo go run ./ build ./test --preserve-import-paths
...
ko.local/foo/github.com/google/ko/test:3a28632fcb886b7a4c78be8cd36c34ec47e83f71ff55353e5602873400dca564
```

```
KO_DOCKER_REPO=ko.local/foo go run ./ build ./test
...
ko.local/foo/test-46c4b272b3716c422d5ff6dfc7547fa9:3a28632fcb886b7a4c78be8cd36c34ec47e83f71ff55353e5602873400dca564
```