### PR TITLE
doc: fix link to Installation page in Getting Started

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-First, [install `ko`](./install).
+First, [install `ko`](../install).
 
 ### Authenticate
 


### PR DESCRIPTION
Fixes the 404 error when clicking the link to the _Installation_ page located at the top of the _Getting Started_ page.