### PR TITLE
truncate -image-refs file

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -248,7 +248,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 	}
 
 	if po.ImageRefsFile != "" {
-		f, err := os.OpenFile(po.ImageRefsFile, os.O_RDWR|os.O_CREATE, 0644)
+		f, err := os.OpenFile(po.ImageRefsFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Before this change, the file at `--image-refs` would be opened, and written to from the beginning. If there were any existing contents in that file already, they would be potentially partially overwritten.

With this change, we open and truncate the file, so that any writes start from the beginning of a fresh new file.

This was reported via https://github.com/knative/serving/pull/13408/