### PR TITLE
add static file paths option

### DIFF
--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -45,27 +45,28 @@ ko apply -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for apply
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                        Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths           Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations       Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings            Filename, directory, or URL to files to use to create the resource
+  -h, --help                        help for apply
+      --image-label strings         Which labels (key=value) to add to the image.
+      --image-refs string           Path to file where a list of the published image references will be written.
+      --insecure-registry           Whether to skip TLS verification on the registry
+  -j, --jobs int                    The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                       Load into images to local docker daemon.
+      --oci-layout-path string      Path to save the OCI image layout of the built images
+      --platform strings            Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths       Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                        Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                   Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string                 The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string             Path to file where the SBOM will be written.
+  -l, --selector string             Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --static-file-paths strings   Which static files (value1,value2...) to add to the image, also supports glob: somepath/*.
+      --tag-only                    Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string              File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -42,24 +42,25 @@ ko build IMPORTPATH... [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -h, --help                     help for build
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                        Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths           Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations       Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                        help for build
+      --image-label strings         Which labels (key=value) to add to the image.
+      --image-refs string           Path to file where a list of the published image references will be written.
+      --insecure-registry           Whether to skip TLS verification on the registry
+  -j, --jobs int                    The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                       Load into images to local docker daemon.
+      --oci-layout-path string      Path to save the OCI image layout of the built images
+      --platform strings            Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths       Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                        Push images to KO_DOCKER_REPO (default true)
+      --sbom string                 The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string             Path to file where the SBOM will be written.
+      --static-file-paths strings   Which static files (value1,value2...) to add to the image, also supports glob: somepath/*.
+      --tag-only                    Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string              File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -45,27 +45,28 @@ ko create -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for create
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                        Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths           Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations       Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings            Filename, directory, or URL to files to use to create the resource
+  -h, --help                        help for create
+      --image-label strings         Which labels (key=value) to add to the image.
+      --image-refs string           Path to file where a list of the published image references will be written.
+      --insecure-registry           Whether to skip TLS verification on the registry
+  -j, --jobs int                    The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                       Load into images to local docker daemon.
+      --oci-layout-path string      Path to save the OCI image layout of the built images
+      --platform strings            Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths       Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                        Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                   Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string                 The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string             Path to file where the SBOM will be written.
+  -l, --selector string             Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --static-file-paths strings   Which static files (value1,value2...) to add to the image, also supports glob: somepath/*.
+      --tag-only                    Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string              File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -38,27 +38,28 @@ ko resolve -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for resolve
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                        Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths           Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations       Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings            Filename, directory, or URL to files to use to create the resource
+  -h, --help                        help for resolve
+      --image-label strings         Which labels (key=value) to add to the image.
+      --image-refs string           Path to file where a list of the published image references will be written.
+      --insecure-registry           Whether to skip TLS verification on the registry
+  -j, --jobs int                    The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                       Load into images to local docker daemon.
+      --oci-layout-path string      Path to save the OCI image layout of the built images
+      --platform strings            Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths       Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                        Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                   Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string                 The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string             Path to file where the SBOM will be written.
+  -l, --selector string             Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --static-file-paths strings   Which static files (value1,value2...) to add to the image, also supports glob: somepath/*.
+      --tag-only                    Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string              File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -30,24 +30,25 @@ ko run IMPORTPATH [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -h, --help                     help for run
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                        Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths           Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations       Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                        help for run
+      --image-label strings         Which labels (key=value) to add to the image.
+      --image-refs string           Path to file where a list of the published image references will be written.
+      --insecure-registry           Whether to skip TLS verification on the registry
+  -j, --jobs int                    The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                       Load into images to local docker daemon.
+      --oci-layout-path string      Path to save the OCI image layout of the built images
+      --platform strings            Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths       Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                        Push images to KO_DOCKER_REPO (default true)
+      --sbom string                 The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string             Path to file where the SBOM will be written.
+      --static-file-paths strings   Which static files (value1,value2...) to add to the image, also supports glob: somepath/*.
+      --tag-only                    Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string              File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -62,8 +62,7 @@ func (a *FlagArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // the original GoReleaser name to match better with the ko naming.
 //
 // TODO: Introduce support for more fields where possible and where it makes
-///      sense for `ko`, for example ModTimestamp or GoBinary.
-//
+// /      sense for `ko`, for example ModTimestamp or GoBinary.
 type Config struct {
 	// ID only serves as an identifier internally
 	ID string `yaml:",omitempty"`
@@ -81,6 +80,9 @@ type Config struct {
 
 	// Env allows setting environment variables for `go build`
 	Env []string `yaml:",omitempty"`
+
+	// StaticFilePaths allows setting paths to static files other than kodata
+	StaticFilePaths []string `yaml:",omitempty"`
 
 	// Other GoReleaser fields that are not supported or do not make sense
 	// in the context of ko, for reference or for future use:

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -177,3 +177,14 @@ func WithSBOMDir(dir string) Option {
 		return nil
 	}
 }
+
+// WithStaticFilePaths is a functional option for adding files to built images.
+func WithStaticFilePaths(staticFilePaths ...string) Option {
+	return func(gbo *gobuildOpener) error {
+		if len(staticFilePaths) == 1 {
+			staticFilePaths = strings.Split(staticFilePaths[0], ",")
+		}
+		gbo.staticFilePaths = staticFilePaths
+		return nil
+	}
+}

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -124,6 +124,10 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		opts = append(opts, build.WithSBOMDir(bo.SBOMDir))
 	}
 
+	if len(bo.StaticFilePaths) > 0 {
+		opts = append(opts, build.WithStaticFilePaths(bo.StaticFilePaths...))
+	}
+
 	return opts, nil
 }
 

--- a/test/migrations/x
+++ b/test/migrations/x
@@ -1,0 +1,1 @@
+New migration


### PR DESCRIPTION
Added the ability to specify paths to static files that will be added to the kodata. 
This can be useful, for example, for adding migrations and configs that are in different folders, so as not to add everything to the kodata folder. 
Support glob syntax. 