### PR TITLE
Layout omit image.ref.name annotation

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -213,7 +213,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 
 		publishers := []publish.Interface{}
 		if po.OCILayoutPath != "" {
-			lp, err := publish.NewLayout(po.OCILayoutPath)
+			lp, err := publish.NewLayout(po.OCILayoutPath, po.Tags...)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create LayoutPublisher for %q: %w", po.OCILayoutPath, err)
 			}

--- a/pkg/publish/layout_test.go
+++ b/pkg/publish/layout_test.go
@@ -25,25 +25,45 @@ import (
 )
 
 func TestLayout(t *testing.T) {
-	img, err := random.Image(1024, 1)
-	if err != nil {
-		t.Fatalf("random.Image() = %v", err)
+	cases := []struct {
+		name string
+		tags []string
+	}{
+		{
+			name: "no tags",
+			tags: nil,
+		}, {
+			name: "foo and bar",
+			tags: []string{"foo", "bar"},
+		}, {
+			name: "latest and foo",
+			tags: []string{"latest", "foo"},
+		},
 	}
-	importpath := "github.com/Google/go-containerregistry/cmd/crane"
 
-	tmp, err := ioutil.TempDir("/tmp", "ko")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			img, err := random.Image(1024, 1)
+			if err != nil {
+				t.Fatalf("random.Image() = %v", err)
+			}
+			importpath := "github.com/example/importpath"
 
-	lp, err := NewLayout(tmp)
-	if err != nil {
-		t.Errorf("NewLayout() = %v", err)
-	}
-	if d, err := lp.Publish(context.Background(), img, importpath); err != nil {
-		t.Errorf("Publish() = %v", err)
-	} else if !strings.HasPrefix(d.String(), tmp) {
-		t.Errorf("Publish() = %v, wanted prefix %v", d, tmp)
+			tmp, err := ioutil.TempDir("/tmp", "ko")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tmp)
+
+			lp, err := NewLayout(tmp, tt.tags...)
+			if err != nil {
+				t.Errorf("NewLayout() = %v", err)
+			}
+			if d, err := lp.Publish(context.Background(), img, importpath); err != nil {
+				t.Errorf("Publish() = %v", err)
+			} else if !strings.HasPrefix(d.String(), tmp) {
+				t.Errorf("Publish() = %v, wanted prefix %v", d, tmp)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #869

Signed-off-by: Furkan <furkan.turkal@trendyol.com>
Co-authored-by: Batuhan <batuhan.apaydin@trendyol.com>

cc @developer-guy

- [ ] tests a bit missing, we will add some assertions to check if all annotations are valid and correct. (if overall idea is OK)

### DEMO

```
$ KO_DOCKER_REPO="foo" LDFLAGS="-s" go run . build -t foo,bar,baz --push=false --oci-layout-path test .

$ cat test/index.json | jq
```

```json
{
  "schemaVersion": 2,
  "manifests": [
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1943,
      "digest": "sha256:99a7a7bf1ad3fde0107b1f5909bb9a1df037f8be8b73e73d1779a0fd473cf1ed",
      "annotations": {
        "org.opencontainers.image.ref.name": "foo"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1943,
      "digest": "sha256:99a7a7bf1ad3fde0107b1f5909bb9a1df037f8be8b73e73d1779a0fd473cf1ed",
      "annotations": {
        "org.opencontainers.image.ref.name": "bar"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1943,
      "digest": "sha256:99a7a7bf1ad3fde0107b1f5909bb9a1df037f8be8b73e73d1779a0fd473cf1ed",
      "annotations": {
        "org.opencontainers.image.ref.name": "baz"
      }
    }
  ]
}
```

