### PR TITLE
ko.build: support some common shortlinks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,3 +40,14 @@ nav:
     - 'ko version': reference/ko_version.md
   - Releases: "https://github.com/ko-build/ko/releases"
 
+plugins:
+  - search
+  - redirects:
+      redirect_maps:
+        'repo.md':      'https://github.com/ko-build/ko'
+        'issues.md':    'https://github.com/ko-build/ko/issues'
+        'prs.md':       'https://github.com/ko-build/ko/pulls'
+        'releases.md':  'https://github.com/ko-build/ko/releases'
+        'godoc.md':     'https://pkg.go.dev/github.com/google/ko'
+        'terraform.md': 'https://github.com/chainguard-dev/terraform-provider-ko'
+        'action.md':    'https://github.com/imjasonh/setup-ko'


### PR DESCRIPTION
This uses https://github.com/mkdocs/mkdocs-redirects to redirect some ko.build paths to external URLs.

For example, https://ko.build/prs will redirect to https://github.com/ko-build/ko/pulls

I tried to figure out how to get ko.build/i/NNN to redirect to a specific issue, but I couldn't get anything to work.

Let me know if there's anything else you think we should add.