### PR TITLE
install mkdocs-redirect when publishing site

### DIFF
--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material 
+      - run: pip install mkdocs-material mkdocs-redirects
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
https://github.com/ko-build/ko/pull/872 added redirects, but didn't install the mkdocs redirect plugin when publishing.