### PR TITLE
install: fail with 404 instead of gzip error when url was wrong

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -3,7 +3,7 @@
 ### Install from [GitHub Releases](https://github.com/ko-build/ko/releases)
 
 ```
-$ VERSION=TODO # choose the latest version
+$ VERSION=TODO # choose the latest version (without v prefix)
 $ OS=Linux     # or Darwin
 $ ARCH=x86_64  # or arm64, i386, s390x
 ```
@@ -12,8 +12,8 @@ We generate [SLSA3 provenance](slsa.dev) using the OpenSSF's [slsa-framework/sls
 
 
 ```shell
-$ curl -sL "https://github.com/ko-build/ko/releases/download/v${VERSION}/ko_${VERSION}_${OS}_${ARCH}.tar.gz" > ko.tar.gz
-$ curl -sL https://github.com/ko-build/ko/releases/download/v${VERSION}/attestation.intoto.jsonl > provenance.intoto.jsonl
+$ curl -sSfL "https://github.com/ko-build/ko/releases/download/v${VERSION}/ko_${VERSION}_${OS}_${ARCH}.tar.gz" > ko.tar.gz
+$ curl -sSfL https://github.com/ko-build/ko/releases/download/v${VERSION}/attestation.intoto.jsonl > provenance.intoto.jsonl
 $ slsa-verifier -artifact-path ko.tar.gz -provenance provenance.intoto.jsonl -source github.com/google/ko -tag "v${VERSION}"
   PASSED: Verified SLSA provenance
 ```
@@ -55,4 +55,3 @@ You can use the [setup-ko](https://github.com/imjasonh/setup-ko) action to insta
 steps:
 - uses: imjasonh/setup-ko@v0.6
 ```
-


### PR DESCRIPTION
```
       -S, --show-error
              When used with -s, --silent, it makes curl show an error message if it fails.
       -f, --fail
              (HTTP) Fail silently (no output at all) on server errors. This is mostly done to enable scripts etc to better deal with failed attempts. In
              normal cases when an HTTP server fails to deliver a document, it returns an HTML document stating so (which often also describes why and
              more). This flag will prevent curl from outputting that and return error 22.
```