### PR TITLE
nit: replace one-item slice with const

### DIFF
--- a/pkg/publish/default.go
+++ b/pkg/publish/default.go
@@ -74,14 +74,14 @@ func identity(base, in string) string { return path.Join(base, in) }
 
 // As some registries do not support pushing an image by digest, the default tag for pushing
 // is the 'latest' tag.
-var defaultTags = []string{"latest"}
+const latestTag = "latest"
 
 func (do *defaultOpener) Open() (Interface, error) {
 	if do.tagOnly {
 		if len(do.tags) != 1 {
 			return nil, errors.New("must specify exactly one tag to resolve images into tag-only references")
 		}
-		if do.tags[0] == defaultTags[0] {
+		if do.tags[0] == latestTag {
 			return nil, errors.New("latest tag cannot be used in tag-only references")
 		}
 	}
@@ -107,7 +107,7 @@ func NewDefault(base string, options ...Option) (Interface, error) {
 		userAgent: "ko",
 		keychain:  authn.DefaultKeychain,
 		namer:     identity,
-		tags:      defaultTags,
+		tags:      []string{latestTag},
 	}
 
 	for _, option := range options {
@@ -244,7 +244,7 @@ func (d *defalt) Publish(ctx context.Context, br build.Result, s string) (name.R
 		return nil, err
 	}
 	ref := fmt.Sprintf("%s@%s", d.namer(d.base, s), h)
-	if len(d.tags) == 1 && d.tags[0] != defaultTags[0] {
+	if len(d.tags) == 1 && d.tags[0] != latestTag {
 		// If a single tag is explicitly set (not latest), then this
 		// is probably a release, so include the tag in the reference.
 		ref = fmt.Sprintf("%s:%s@%s", d.namer(d.base, s), d.tags[0], h)

--- a/pkg/publish/tarball.go
+++ b/pkg/publish/tarball.go
@@ -79,7 +79,7 @@ func (t *tar) Publish(_ context.Context, br build.Result, s string) (name.Refere
 	}
 
 	ref := fmt.Sprintf("%s@%s", t.namer(t.base, s), h)
-	if len(t.tags) == 1 && t.tags[0] != defaultTags[0] {
+	if len(t.tags) == 1 && t.tags[0] != latestTag {
 		// If a single tag is explicitly set (not latest), then this
 		// is probably a release, so include the tag in the reference.
 		ref = fmt.Sprintf("%s:%s@%s", t.namer(t.base, s), t.tags[0], h)


### PR DESCRIPTION
Noticed this while reviewing https://github.com/ko-build/ko/pull/884 -- it's weird that `defaultTags` is always a slice (and necessarily a `var`) when we only care about its only element, which is `"latest"`.