### PR TITLE
update docs to reflect actual default base image

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ Aside from `KO_DOCKER_REPO`, you can configure `ko`'s behavior using a
 
 ### Overriding Base Images
 
-By default, `ko` bases images on `gcr.io/distroless/static:nonroot`. This is a
+By default, `ko` bases images on `cgr.dev/chainguard/static`. This is a
 small image that provides the bare necessities to run your Go binary.
 
 You can override this base image in two ways:

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// configDefaultBaseImage is the default base image if not specified in .ko.yaml.
-	configDefaultBaseImage = "distroless.dev/static:latest"
+	configDefaultBaseImage = "cgr.dev/chainguard/static:latest"
 )
 
 // BuildOptions represents options for the ko builder.


### PR DESCRIPTION
distroless.dev/static redirects to exactly the same location as cgr.dev/chainguard/static (and will indefinitely). cgr.dev has the added benefit that it has probers and oncall.

The docs change is more important; that was just plain incorrect since [`v0.12.0`](https://github.com/ko-build/ko/releases/tag/v0.12.0).