### PR TITLE
use cgr.dev for base img make the const accessible

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -35,6 +35,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/spf13/viper"
+
 	"github.com/containerd/stargz-snapshotter/estargz"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -57,6 +59,14 @@ import (
 const (
 	defaultAppFilename = "ko-app"
 )
+
+// DefaultBaseImage returns the default base image to use
+func DefaultBaseImage() (ref string, err error) {
+	if !viper.IsSet("defaultBaseImage") {
+		return "", errors.New("'defaultBaseImage' is not set")
+	}
+	return viper.GetString("defaultBaseImage"), nil
+}
 
 // GetBase takes an importpath and returns a base image reference and base image (or index).
 type GetBase func(context.Context, string) (name.Reference, Result, error)

--- a/pkg/commands/options/build_test.go
+++ b/pkg/commands/options/build_test.go
@@ -15,6 +15,7 @@
 package options
 
 import (
+	"errors"
 	"os"
 	"reflect"
 	"strings"
@@ -35,6 +36,19 @@ func TestDefaultBaseImage(t *testing.T) {
 
 	wantDefaultBaseImage := "alpine" // matches value in ./testdata/config/.ko.yaml
 	if bo.BaseImage != wantDefaultBaseImage {
+		t.Fatalf("wanted BaseImage %s, got %s", wantDefaultBaseImage, bo.BaseImage)
+	}
+
+	defaultBaseImageRef, err := build.DefaultBaseImage()
+	if err != nil {
+		t.Fatalf("DefaultBaseImage() = %v", err)
+	}
+
+	if defaultBaseImageRef == "" {
+		t.Fatalf("DefaultBaseImage() = %v", errors.New("empty default base image"))
+	}
+
+	if defaultBaseImageRef != wantDefaultBaseImage {
 		t.Fatalf("wanted BaseImage %s, got %s", wantDefaultBaseImage, bo.BaseImage)
 	}
 }

--- a/pkg/commands/publisher_test.go
+++ b/pkg/commands/publisher_test.go
@@ -18,6 +18,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -72,6 +73,16 @@ func TestPublishImages(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: MakeBuilder(): %v", test.description, err)
 		}
+
+		defaultBaseImageRef, err := build.DefaultBaseImage()
+		if err != nil {
+			t.Fatalf("DefaultBaseImage() = %v", err)
+		}
+
+		if defaultBaseImageRef == "" {
+			t.Fatalf("DefaultBaseImage() = %v", errors.New("empty default base image"))
+		}
+
 		po := &options.PublishOptions{
 			DockerRepo:          repo,
 			PreserveImportPaths: true,


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

According to the comment [here](https://github.com/goreleaser/goreleaser/pull/3490/files#r1036136408)