### PR TITLE
Add --all option to build command

### DIFF
--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -42,6 +42,7 @@ ko build IMPORTPATH... [flags]
 ### Options
 
 ```
+      --all                      When given, build all configured targets.
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -60,11 +60,6 @@ func addBuild(topLevel *cobra.Command) {
 				return fmt.Errorf("validating options: %w", err)
 			}
 
-			if len(args) == 0 {
-				// Build the current directory by default.
-				args = []string{"."}
-			}
-
 			ctx := cmd.Context()
 
 			bo.InsecureRegistry = po.InsecureRegistry
@@ -72,6 +67,23 @@ func addBuild(topLevel *cobra.Command) {
 			if err != nil {
 				return fmt.Errorf("error creating builder: %w", err)
 			}
+
+			if bo.BuildAll {
+				if len(args) != 0 {
+					return fmt.Errorf("no paths should be given when --all is set")
+				}
+				if len(bo.BuildConfigs) == 0 {
+					return fmt.Errorf("--all is set, but found no build configurations")
+				}
+
+				for _, cfg := range bo.BuildConfigs {
+					args = append(args, cfg.Main)
+				}
+			} else if len(args) == 0 {
+				// Build the current directory by default.
+				args = []string{"."}
+			}
+
 			publisher, err := makePublisher(po)
 			if err != nil {
 				return fmt.Errorf("error creating publisher: %w", err)

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -69,6 +69,8 @@ type BuildOptions struct {
 	// `AddBuildOptions()` defaults this field to `true`.
 	Trimpath bool
 
+	BuildAll bool
+
 	// BuildConfigs stores the per-image build config from `.ko.yaml`.
 	BuildConfigs map[string]build.Config
 }
@@ -86,6 +88,8 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
+	cmd.Flags().BoolVar(&bo.BuildAll, "all", false,
+		"When given, build all configured targets.")
 	bo.Trimpath = true
 }
 


### PR DESCRIPTION
This PR adds an `--all` flag to the `build` command, allowing to build all targets specified in `.ko.yaml`. 

Fixes #643