### PR TITLE
fix: possible race condition when applying templates to flags/ldflags

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -700,7 +700,7 @@ func createTemplateData() map[string]interface{} {
 }
 
 func applyTemplating(list []string, data map[string]interface{}) ([]string, error) {
-	result := make([]string, len(list), 0)
+	result := make([]string, 0, len(list))
 	for _, entry := range list {
 		tmpl, err := template.New("argsTmpl").Option("missingkey=error").Parse(entry)
 		if err != nil {


### PR DESCRIPTION
while working on https://github.com/goreleaser/goreleaser/pull/3653, I got some race conditions sometimes.

Seems to happen when the base image is a image index, in which case it'll build for all platform needed concurrently, which is when we get the concurrent writes.

I don't see a big issue in returning a copy instead, not sure what you think.

PS: Its late here, so please pardon me if I'm doing something dumb 😂