### PR TITLE
remove repeated error message on failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 	"os/signal"
 
@@ -29,6 +28,6 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 	if err := commands.Root.ExecuteContext(ctx); err != nil {
-		log.Fatal("error during command execution:", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Cobra logs error messages before passing them to us, so we don't need to re-log it.

Before:

```
ko build ./blah
Error: failed to publish images: importpath "ko://./blah" is not supported: importpath is not `package main`
2023/01/04 11:30:41 error during command execution:failed to publish images: importpath "ko://./blah" is not supported: importpath is not `package main`
exit status 1
```

After:

```
go run . build ./blah
Error: failed to publish images: importpath "ko://./blah" is not supported: importpath is not `package main`
exit status 1
```