### PR TITLE
add ko.build/slack short link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,3 +51,4 @@ plugins:
         'godoc.md':     'https://pkg.go.dev/github.com/google/ko'
         'terraform.md': 'https://github.com/ko-build/terraform-provider-ko'
         'action.md':    'https://github.com/ko-build/setup-ko'
+        'slack.md':     'https://kubernetes.slack.com/archives/C01T7DTP65S'


### PR DESCRIPTION
This will make https://ko.build/slack link to the `#ko-build` Slack channel on the Kubernetes Slack.