### PR TITLE
fix: handle docker's unknown/unknown platform in index manifests

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -1171,6 +1171,13 @@ func parseSpec(spec []string) (*platformMatcher, error) {
 }
 
 func (pm *platformMatcher) matches(base *v1.Platform) bool {
+	// Strip out manifests with "unknown/unknown" platform, which Docker uses
+	// to store provenance attestations.
+	if base != nil &&
+		(base.OS == "unknown" || base.Architecture == "unknown") {
+		return false
+	}
+
 	if len(pm.spec) > 0 && pm.spec[0] == "all" {
 		return true
 	}

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -1139,6 +1139,11 @@ func TestMatchesPlatformSpec(t *testing.T) {
 			OSVersion:    "10.0.17763.1234.5678", // this won't happen in the wild, but it shouldn't match.
 		},
 		result: false,
+	}, {
+		// Even --platform=all does not match unknown/unknown.
+		platform: &v1.Platform{Architecture: "unknown", OS: "unknown"},
+		spec:     []string{"all"},
+		result:   false,
 	}} {
 		pm, err := parseSpec(tc.spec)
 		if tc.err {


### PR DESCRIPTION
Docker decided to include provenance attestations in index manifests, with descriptors having the platform `unknown/unknown`: https://docs.docker.com/build/attestations/attestation-storage/#image-index-sha25694acc2ca70c40f3f6291681f37ce9c767e3d251ce01c7e4e9b98ccf148c26260

This causes problems for `ko build --platform=all` since `unknown/unknown` is not a, well, known GOOS/GOARCH, in accordance with the [OCI image spec](https://github.com/opencontainers/image-spec/blob/main/image-index.md#image-index-property-descriptions).

This change ignores `unknown/unknown` when trying to match a multi-arch base image's platforms, even when using `--platform=all`.