### PR TITLE
fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           tag=$(echo ${{ github.ref }} | cut -c11-) # get tag name without tags/refs/ prefix.
           img=$(ko build --bare --platform=all -t latest -t ${{ github.sha }} -t ${tag} ./)
           echo "built ${img}"
-          cosign sign ${img} \
+          cosign sign ${img} --yes \
               -a sha=${{ github.sha }} \
               -a run_id=${{ github.run_id }} \
               -a run_attempt=${{ github.run_attempt }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           echo "::set-output name=hashes::$(cat $checksum_file | base64 -w0)"
 
   publish:
+    needs: [goreleaser]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This breaks because the release doesn't have a built `ko` binary yet.

This only runs `publish` after the `goreleaser` job has finished and binaries are available.

I think we could also just remember not to check "this is the latest release" when cutting a new release, but I will never remember to do that.

For this release I'm just going to retry the failed job after `goreleaser` finishes.