### PR TITLE
fix: Use attestation-name output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,6 @@ jobs:
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true
-      compile-generator: true # Workaround for https://github.com/slsa-framework/slsa-github-generator/issues/1163
 
   verification:
     needs: [goreleaser, provenance]
@@ -93,11 +92,12 @@ jobs:
       - name: Download assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROVENANCE: "${{ needs.provenance.outputs.attestation-name }}"
         run: |
           set -euo pipefail
 
           gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "*.tar.gz"
-          gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "attestation.intoto.jsonl"
+          gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "$PROVENANCE"
 
       - name: Verify assets
         env:


### PR DESCRIPTION
Fixes #978 

Uses the `attestation-name` output from `generator_generic_slsa3.yml` to get the artifact name to download.

Also removes the `compile-generator` input as https://github.com/slsa-framework/slsa-github-generator/issues/1163 was fixed.