### PR TITLE
try to fix codeql workflow

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -11,15 +11,18 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
     steps:
     - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
-
-    - uses: github/codeql-action/init@a589d4087ea22a0a48fc153d1b461886e262e0f2 # v2.2.7
+    - uses: github/codeql-action/init@168b99b3c22180941ae7dbdd5f5c9678ede476ba # v2.2.7
       with:
         languages: go
-    - uses: github/codeql-action/autobuild@a589d4087ea22a0a48fc153d1b461886e262e0f2 # v2.2.7
-    - uses: github/codeql-action/analyze@a589d4087ea22a0a48fc153d1b461886e262e0f2 # v2.2.7
+    - uses: github/codeql-action/autobuild@168b99b3c22180941ae7dbdd5f5c9678ede476ba # v2.2.7
+    - uses: github/codeql-action/analyze@168b99b3c22180941ae7dbdd5f5c9678ede476ba # v2.2.7


### PR DESCRIPTION
Recently the `Analyze` workflow has started to fail mysteriously (see https://github.com/ko-build/ko/pull/991)

The commit we pin two is [only a few weeks old](https://github.com/github/codeql-action/commit/a589d4087ea22a0a48fc153d1b461886e262e0f2/) but there have been [some changes](https://github.com/github/codeql-action/compare/a589d4087ea22a0a48fc153d1b461886e262e0f2...168b99b3c22180941ae7dbdd5f5c9678ede476ba) particularly https://github.com/github/codeql-action/commit/100bd7bbef94953be41fddd5afa784161cf2b4c5 which seems like it might be the fix.

I'm not sure why `168b999` was picked up, as it's not (currently) `v2.2.7` -- maybe they retagged to pick up the fix, I'm not sure.