### PR TITLE
Add entrypoint args to built docker image

### DIFF
--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -177,3 +177,11 @@ func WithSBOMDir(dir string) Option {
 		return nil
 	}
 }
+
+// WithEntrypointArgs to be appended to entrypoint
+func WithEntrypointArgs(epa string) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.entrypointArgs = strings.Split(epa, " ")
+		return nil
+	}
+}

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -68,6 +68,7 @@ func addBuild(topLevel *cobra.Command) {
 			ctx := cmd.Context()
 
 			bo.InsecureRegistry = po.InsecureRegistry
+			bo.EntrypointArgs = po.EntrypointArgs
 			builder, err := makeBuilder(ctx, bo)
 			if err != nil {
 				return fmt.Errorf("error creating builder: %w", err)

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -71,6 +71,9 @@ type BuildOptions struct {
 
 	// BuildConfigs stores the per-image build config from `.ko.yaml`.
 	BuildConfigs map[string]build.Config
+
+	// EntyrpointArgs
+	EntrypointArgs string
 }
 
 func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {

--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -72,6 +72,9 @@ type PublishOptions struct {
 	ImageNamer publish.Namer
 
 	Jobs int
+
+	// EntrypointArgs (optional) entrypoint arguments
+	EntrypointArgs string
 }
 
 func AddPublishArg(cmd *cobra.Command, po *PublishOptions) {
@@ -106,6 +109,8 @@ func AddPublishArg(cmd *cobra.Command, po *PublishOptions) {
 		"Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).")
 	cmd.Flags().BoolVar(&po.Bare, "bare", po.Bare,
 		"Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).")
+	cmd.Flags().StringVar(&po.EntrypointArgs, "args", "",
+		"Executable command arguments added to entrypoint.")
 }
 
 func packageWithMD5(base, importpath string) string {

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -91,6 +91,7 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		build.WithBaseImages(getBaseImage(bo)),
 		build.WithPlatforms(bo.Platforms...),
 		build.WithJobs(bo.ConcurrentBuilds),
+		build.WithEntrypointArgs(bo.EntrypointArgs),
 	}
 	if creationTime != nil {
 		opts = append(opts, build.WithCreationTime(*creationTime))


### PR DESCRIPTION
Added `--args` to `ko build`: one string with args to be added to go executable (`appPath` in `pkg/build/gobuild.go`).

```
$ # normal
$ ko build cmd/app
$ docker inspect <image> | grep -A 5 Entrypoint
            "Entrypoint": [
                "/ko-app/app",
            ],
            "OnBuild": null,
...
$ # with args
$ ko build --args "-c /pvc-config/config.json" cmd/app
$ docker inspect <image> | grep -A 5 Entrypoint
            "Entrypoint": [
                "/ko-app/app",
                "-c",
                "/pcv-config/config.json",
            ],
            "OnBuild": null,
```