### PR TITLE
Fix kind image names with --bare

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -199,7 +199,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 			)
 		}
 		if strings.HasPrefix(repoName, publish.KindDomain) {
-			return publish.NewKindPublisher(namer, po.Tags), nil
+			return publish.NewKindPublisher(repoName, namer, po.Tags), nil
 		}
 
 		if repoName == "" && po.Push {

--- a/pkg/publish/kind.go
+++ b/pkg/publish/kind.go
@@ -33,13 +33,15 @@ const (
 )
 
 type kindPublisher struct {
+	base  string
 	namer Namer
 	tags  []string
 }
 
 // NewKindPublisher returns a new publish.Interface that loads images into kind nodes.
-func NewKindPublisher(namer Namer, tags []string) Interface {
+func NewKindPublisher(base string, namer Namer, tags []string) Interface {
 	return &kindPublisher{
+		base:  base,
 		namer: namer,
 		tags:  tags,
 	}
@@ -96,7 +98,7 @@ func (t *kindPublisher) Publish(ctx context.Context, br build.Result, s string) 
 		return nil, err
 	}
 
-	digestTag, err := name.NewTag(fmt.Sprintf("%s:%s", t.namer(KindDomain, s), h.Hex))
+	digestTag, err := name.NewTag(fmt.Sprintf("%s:%s", t.namer(t.base, s), h.Hex))
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +111,7 @@ func (t *kindPublisher) Publish(ctx context.Context, br build.Result, s string) 
 
 	for _, tagName := range t.tags {
 		log.Printf("Adding tag %v", tagName)
-		tag, err := name.NewTag(fmt.Sprintf("%s:%s", t.namer(KindDomain, s), tagName))
+		tag, err := name.NewTag(fmt.Sprintf("%s:%s", t.namer(t.base, s), tagName))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Make the functionality match between:
KO_DOCKER_REPO=ko.local/my-image ko build --bare

And:
KO_DOCKER_REPO=kind.local/my-image ko build --bare

As it stands, `--bare` is broken with `kind.local/` as it just gets `kind.local` as the image name, and then it fails to tag because the registry is missing.