### PR TITLE
Allow specification of the binary name/path

### DIFF
--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -81,6 +81,9 @@ type Config struct {
 	// Env allows setting environment variables for `go build`
 	Env []string `yaml:",omitempty"`
 
+	// Binary allows setting the name of the binary
+	Binary string `yaml:",omitempty"`
+
 	// Other GoReleaser fields that are not supported or do not make sense
 	// in the context of ko, for reference or for future use:
 	// Goos         []string    `yaml:",omitempty"`
@@ -88,7 +91,6 @@ type Config struct {
 	// Goarm        []string    `yaml:",omitempty"`
 	// Gomips       []string    `yaml:",omitempty"`
 	// Targets      []string    `yaml:",omitempty"`
-	// Binary       string      `yaml:",omitempty"`
 	// Lang         string      `yaml:",omitempty"`
 	// Asmflags     StringArray `yaml:",omitempty"`
 	// Gcflags      StringArray `yaml:",omitempty"`

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -830,8 +830,9 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 	if !g.platformMatcher.matches(platform) {
 		return nil, fmt.Errorf("base image platform %q does not match desired platforms %v", platform, g.platformMatcher.platforms)
 	}
+	conf := g.configForImportPath(ref.Path())
 	// Do the build into a temporary file.
-	file, err := g.build(ctx, ref.Path(), g.dir, *platform, g.configForImportPath(ref.Path()))
+	file, err := g.build(ctx, ref.Path(), g.dir, *platform, conf)
 	if err != nil {
 		return nil, fmt.Errorf("build: %w", err)
 	}
@@ -865,6 +866,14 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 
 	appDir := "/ko-app"
 	appFileName := appFilename(ref.Path())
+	if conf.Binary != "" {
+		if path.IsAbs(conf.Binary) {
+			appDir = path.Dir(conf.Binary)
+			appFileName = path.Base(conf.Binary)
+		} else {
+			appFileName = conf.Binary
+		}
+	}
 	appPath := path.Join(appDir, appFileName)
 
 	miss := func() (v1.Layer, error) {


### PR DESCRIPTION
Some container usage expects to run an executable in a specific location, and some projects aren't well laid out to generate binaries with the expected names.

This allows the binary name to be specified in configuration (in a similar way to goreleaser), which should allow for easier migration from other build mechanisms (and usage patterns of their images) to `ko`.

This does not affect the name or path for Windows builds - the path structure is fundamentally different, and I think that if it's desirable to change the name/path for them, we should use a separate config argument.

connects #944