### PR TITLE
Revert "Fix kind image loading for MacOS"

### DIFF
--- a/pkg/publish/kind/write.go
+++ b/pkg/publish/kind/write.go
@@ -69,7 +69,7 @@ func Write(ctx context.Context, tag name.Tag, img v1.Image) error {
 		})
 
 		var buf bytes.Buffer
-		cmd := n.CommandContext(ctx, "ctr", "--namespace=k8s.io", "images", "import", "--all-platforms", "-").SetStdin(pr)
+		cmd := n.CommandContext(ctx, "ctr", "--namespace=k8s.io", "images", "import", "-").SetStdin(pr)
 		cmd.SetStdout(&buf)
 		cmd.SetStderr(&buf)
 		if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Reverts ko-build/ko#1026

This failed unit tests: https://github.com/ko-build/ko/actions/runs/5058723077/jobs/9079218316

```
--- FAIL: TestWrite (0.02s)
    write_test.go:62: c.cmd = ctr --namespace=k8s.io images import --all-platforms -, want ctr --namespace=k8s.io images import -

```