### PR TITLE
support --platform=wasip1/wasm

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
     - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
       with:
-        go-version: '1.20'
+        go-version: '1.21.x'
         check-latest: true
 
     - name: Build and run ko container
@@ -48,15 +48,15 @@ jobs:
         jq . ./sbom-data2/test-linux-amd64.spdx.json
         jq . ./sbom-data2/test-linux-arm64.spdx.json
 
-        export PLATFORM=${GOOS}/${GOARCH}
+        export PLATFORM=linux/amd64
 
         if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
           OSVERSION="10.0.20348"
-          PLATFORM=${PLATFORM}:${OSVERSION}
+          PLATFORM=windows/amd64:${OSVERSION}
           export KO_DEFAULTBASEIMAGE=mcr.microsoft.com/windows/nanoserver:ltsc2022
         else
           # Explicitly test multiple platform builds (a subset of what's in the base!)
-          export PLATFORM=${PLATFORM},linux/arm64
+          PLATFORM=${PLATFORM},linux/arm64
         fi
 
         echo platform is ${PLATFORM}
@@ -82,3 +82,9 @@ jobs:
           - "-X main.version=${{ github.sha }}"
         EOF
         docker run $(go run ./ build ./test/ --platform=${PLATFORM}) --wait=false 2>&1 | grep "${{ github.sha }}"
+
+        if [[ "${{ matrix.platform }}" != "windows-latest" ]]; then
+          # Check that we can build for wasm (from linux)
+          # TODO: Run the image.
+          go run ./ build ./test/ --platform=wasip1/wasm
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 ko
 
 .DS_Store
+
+*.wasm

--- a/docs/features/wasm.md
+++ b/docs/features/wasm.md
@@ -1,0 +1,30 @@
+# Wasm
+
+`ko` has early **experimental** support for building wasm containers.
+
+This currently requrires:
+
+- `ko` built from head (`go install github.com/google/ko@main`)
+- [Go 1.21](https://go.dev/dl/) or later
+- [up-to-date Docker Desktop with experimental features enabled](https://docs.docker.com/desktop/wasm/)
+
+With those requirements met, you can build a wasm container with:
+
+```sh
+ko build ./cmd/app --platform=wasip1/wasm
+```
+
+You can then run this image with:
+
+```sh
+docker run \
+  --runtime=io.containerd.wasmedge.v1 \
+  --platform=wasip1/wasm \
+  ${IMAGE}
+```
+
+### Known Limitations
+
+- SBOMs are not generated for containers built this way
+- `--platform` must only specify `wasip1/wasm`, and no other platforms
+- Test coverage is limited. [Anecdotally](https://github.com/ko-build/ko/pull/1095), the `wasmedge` and `wasmtime` runtimes should work, but `slight` and `spin` do not currently.

--- a/test/main_other.go
+++ b/test/main_other.go
@@ -1,0 +1,34 @@
+//go:build !wasm
+// +build !wasm
+
+// Copyright 2023 ko Build Authors All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func test() {
+	dp := os.Getenv("KO_DATA_PATH")
+	file := filepath.Join(dp, *f)
+	bytes, err := os.ReadFile(file)
+	if err != nil {
+		log.Fatalf("Error reading %q: %v", file, err)
+	}
+	log.Print(string(bytes))
+}

--- a/test/main_wasm.go
+++ b/test/main_wasm.go
@@ -1,0 +1,24 @@
+//go:build wasm
+// +build wasm
+
+// Copyright 2023 ko Build Authors All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "log"
+
+func test() {
+	log.Println("Hello, adventurous wasm user!")
+}


### PR DESCRIPTION
In order to use this, you need:
- [Go 1.21](https://go.dev/dl/#go1.21.0)
- [up-to-date Docker Desktop with experimental features enabled](https://docs.docker.com/desktop/wasm/)

```
go run ./ build ./test --platform wasip1/wasm
```

When run this way, instead of producing `/ko-app/test`, it produces `/ko-app/test.wasm` on top of an empty base image.

You can run this image with:

```
docker run \                                         
  --runtime=io.containerd.wasmedge.v1 \
  --platform=wasip1/wasm \
  ${IMAGE}
```

Or, all together in one big blob:

```
$ docker run \                                         
  --runtime=io.containerd.wasmedge.v1 \
  --platform=wasip1/wasm \
  $(KO_DOCKER_REPO=ttl.sh/jason KO_GO_PATH=go1.21rc2 go run ./ build ./test --platform wasip1/wasm) --wait=false
...
Unable to find image 'ttl.sh/jason/test-46c4b272b3716c422d5ff6dfc7547fa9@sha256:a0c4ec41385b5739a22e2557d374298938dea07385d6cf4c1d2e09931df7c7de' locally
a0c4ec41385b: Download complete 
d37e65aa4221: Download complete 
3827f8e0b338: Download complete 
2023/07/14 00:22:01 version = default
2023/07/14 00:22:01 Hello, adventurous wasm user!
```

Known issues:
- `go version -m test.wasm` doesn't work, so the SBOM is empty
- `--platform=linux/amd64,wasip1/wasm` doesn't work, and it's unclear if anything could run it anyway