### PR TITLE
Add support for setting POSIX capabilities on the binary generated by Go

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,3 +151,16 @@ cluster, if available, by setting `KO_DOCKER_REPO=kind.local`. By default this
 loads into the default KinD cluster name (`kind`). To load into another KinD
 cluster, set `KIND_CLUSTER_NAME=my-other-cluster`.
 
+## Setting POSIX capabilities on the binary executable in the container image
+
+For a binary to perform certain privileged operations, it needs to be run with
+the appropriate POSIX capabilities. `ko` supports setting the capability attribute
+on the binary executable in the container image. This indicates to the operating
+system that the binary should be run with the specified capabilities. In docker,
+for example, this means that the binary has to be run with the appropriate
+`--cap-add` flags. In Kubernetes, this means that the binary has to be run with
+the appropriate `securityContext` settings.
+
+```console
+ko build --cap-add CAP_IPC_LOCK ./cmd/app
+```

--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -45,27 +45,28 @@ ko apply -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for apply
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                         Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths            Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations        Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings             Filename, directory, or URL to files to use to create the resource
+  -h, --help                         help for apply
+      --image-label strings          Which labels (key=value) to add to the image.
+      --image-refs string            Path to file where a list of the published image references will be written.
+      --insecure-registry            Whether to skip TLS verification on the registry
+  -j, --jobs int                     The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                        Load into images to local docker daemon.
+      --oci-layout-path string       Path to save the OCI image layout of the built images
+      --platform strings             Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+      --posix-capabilities strings   Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
+  -P, --preserve-import-paths        Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                         Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                    Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string                  The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string              Path to file where the SBOM will be written.
+  -l, --selector string              Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                     Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                 Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string               File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -45,28 +45,28 @@ ko apply -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                         Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths            Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations        Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings             Filename, directory, or URL to files to use to create the resource
-  -h, --help                         help for apply
-      --image-label strings          Which labels (key=value) to add to the image.
-      --image-refs string            Path to file where a list of the published image references will be written.
-      --insecure-registry            Whether to skip TLS verification on the registry
-  -j, --jobs int                     The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                        Load into images to local docker daemon.
-      --oci-layout-path string       Path to save the OCI image layout of the built images
-      --platform strings             Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-      --posix-capabilities strings   Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
-  -P, --preserve-import-paths        Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                         Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                    Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string                  The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string              Path to file where the SBOM will be written.
-  -l, --selector string              Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                     Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings                 Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string               File to save images tarballs
+      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --cap-add strings          Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
+      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
+  -h, --help                     help for apply
+      --image-label strings      Which labels (key=value) to add to the image.
+      --image-refs string        Path to file where a list of the published image references will be written.
+      --insecure-registry        Whether to skip TLS verification on the registry
+  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                    Load into images to local docker daemon.
+      --oci-layout-path string   Path to save the OCI image layout of the built images
+      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                     Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string          Path to file where the SBOM will be written.
+  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string           File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -42,24 +42,25 @@ ko build IMPORTPATH... [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -h, --help                     help for build
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                         Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths            Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations        Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                         help for build
+      --image-label strings          Which labels (key=value) to add to the image.
+      --image-refs string            Path to file where a list of the published image references will be written.
+      --insecure-registry            Whether to skip TLS verification on the registry
+  -j, --jobs int                     The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                        Load into images to local docker daemon.
+      --oci-layout-path string       Path to save the OCI image layout of the built images
+      --platform strings             Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+      --posix-capabilities strings   Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
+  -P, --preserve-import-paths        Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                         Push images to KO_DOCKER_REPO (default true)
+      --sbom string                  The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string              Path to file where the SBOM will be written.
+      --tag-only                     Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                 Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string               File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -42,25 +42,25 @@ ko build IMPORTPATH... [flags]
 ### Options
 
 ```
-      --bare                         Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths            Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations        Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -h, --help                         help for build
-      --image-label strings          Which labels (key=value) to add to the image.
-      --image-refs string            Path to file where a list of the published image references will be written.
-      --insecure-registry            Whether to skip TLS verification on the registry
-  -j, --jobs int                     The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                        Load into images to local docker daemon.
-      --oci-layout-path string       Path to save the OCI image layout of the built images
-      --platform strings             Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-      --posix-capabilities strings   Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
-  -P, --preserve-import-paths        Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                         Push images to KO_DOCKER_REPO (default true)
-      --sbom string                  The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string              Path to file where the SBOM will be written.
-      --tag-only                     Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings                 Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string               File to save images tarballs
+      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --cap-add strings          Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
+      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                     help for build
+      --image-label strings      Which labels (key=value) to add to the image.
+      --image-refs string        Path to file where a list of the published image references will be written.
+      --insecure-registry        Whether to skip TLS verification on the registry
+  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                    Load into images to local docker daemon.
+      --oci-layout-path string   Path to save the OCI image layout of the built images
+      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                     Push images to KO_DOCKER_REPO (default true)
+      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string          Path to file where the SBOM will be written.
+      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string           File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -45,28 +45,28 @@ ko create -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                         Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths            Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations        Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings             Filename, directory, or URL to files to use to create the resource
-  -h, --help                         help for create
-      --image-label strings          Which labels (key=value) to add to the image.
-      --image-refs string            Path to file where a list of the published image references will be written.
-      --insecure-registry            Whether to skip TLS verification on the registry
-  -j, --jobs int                     The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                        Load into images to local docker daemon.
-      --oci-layout-path string       Path to save the OCI image layout of the built images
-      --platform strings             Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-      --posix-capabilities strings   Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
-  -P, --preserve-import-paths        Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                         Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                    Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string                  The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string              Path to file where the SBOM will be written.
-  -l, --selector string              Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                     Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings                 Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string               File to save images tarballs
+      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --cap-add strings          Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
+      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
+  -h, --help                     help for create
+      --image-label strings      Which labels (key=value) to add to the image.
+      --image-refs string        Path to file where a list of the published image references will be written.
+      --insecure-registry        Whether to skip TLS verification on the registry
+  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                    Load into images to local docker daemon.
+      --oci-layout-path string   Path to save the OCI image layout of the built images
+      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                     Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string          Path to file where the SBOM will be written.
+  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string           File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -45,27 +45,28 @@ ko create -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for create
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                         Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths            Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations        Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings             Filename, directory, or URL to files to use to create the resource
+  -h, --help                         help for create
+      --image-label strings          Which labels (key=value) to add to the image.
+      --image-refs string            Path to file where a list of the published image references will be written.
+      --insecure-registry            Whether to skip TLS verification on the registry
+  -j, --jobs int                     The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                        Load into images to local docker daemon.
+      --oci-layout-path string       Path to save the OCI image layout of the built images
+      --platform strings             Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+      --posix-capabilities strings   Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
+  -P, --preserve-import-paths        Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                         Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                    Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string                  The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string              Path to file where the SBOM will be written.
+  -l, --selector string              Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                     Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                 Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string               File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -38,27 +38,28 @@ ko resolve -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for resolve
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                         Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths            Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations        Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings             Filename, directory, or URL to files to use to create the resource
+  -h, --help                         help for resolve
+      --image-label strings          Which labels (key=value) to add to the image.
+      --image-refs string            Path to file where a list of the published image references will be written.
+      --insecure-registry            Whether to skip TLS verification on the registry
+  -j, --jobs int                     The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                        Load into images to local docker daemon.
+      --oci-layout-path string       Path to save the OCI image layout of the built images
+      --platform strings             Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+      --posix-capabilities strings   Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
+  -P, --preserve-import-paths        Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                         Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                    Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string                  The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string              Path to file where the SBOM will be written.
+  -l, --selector string              Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                     Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                 Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string               File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -38,28 +38,28 @@ ko resolve -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                         Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths            Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations        Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings             Filename, directory, or URL to files to use to create the resource
-  -h, --help                         help for resolve
-      --image-label strings          Which labels (key=value) to add to the image.
-      --image-refs string            Path to file where a list of the published image references will be written.
-      --insecure-registry            Whether to skip TLS verification on the registry
-  -j, --jobs int                     The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                        Load into images to local docker daemon.
-      --oci-layout-path string       Path to save the OCI image layout of the built images
-      --platform strings             Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-      --posix-capabilities strings   Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
-  -P, --preserve-import-paths        Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                         Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                    Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string                  The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string              Path to file where the SBOM will be written.
-  -l, --selector string              Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                     Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings                 Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string               File to save images tarballs
+      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --cap-add strings          Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
+      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
+  -h, --help                     help for resolve
+      --image-label strings      Which labels (key=value) to add to the image.
+      --image-refs string        Path to file where a list of the published image references will be written.
+      --insecure-registry        Whether to skip TLS verification on the registry
+  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                    Load into images to local docker daemon.
+      --oci-layout-path string   Path to save the OCI image layout of the built images
+      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                     Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string          Path to file where the SBOM will be written.
+  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string           File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -30,25 +30,25 @@ ko run IMPORTPATH [flags]
 ### Options
 
 ```
-      --bare                         Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths            Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations        Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -h, --help                         help for run
-      --image-label strings          Which labels (key=value) to add to the image.
-      --image-refs string            Path to file where a list of the published image references will be written.
-      --insecure-registry            Whether to skip TLS verification on the registry
-  -j, --jobs int                     The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                        Load into images to local docker daemon.
-      --oci-layout-path string       Path to save the OCI image layout of the built images
-      --platform strings             Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-      --posix-capabilities strings   Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
-  -P, --preserve-import-paths        Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                         Push images to KO_DOCKER_REPO (default true)
-      --sbom string                  The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string              Path to file where the SBOM will be written.
-      --tag-only                     Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings                 Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string               File to save images tarballs
+      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --cap-add strings          Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
+      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                     help for run
+      --image-label strings      Which labels (key=value) to add to the image.
+      --image-refs string        Path to file where a list of the published image references will be written.
+      --insecure-registry        Whether to skip TLS verification on the registry
+  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                    Load into images to local docker daemon.
+      --oci-layout-path string   Path to save the OCI image layout of the built images
+      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                     Push images to KO_DOCKER_REPO (default true)
+      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string          Path to file where the SBOM will be written.
+      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string           File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -30,24 +30,25 @@ ko run IMPORTPATH [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -h, --help                     help for run
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                         Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths            Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations        Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                         help for run
+      --image-label strings          Which labels (key=value) to add to the image.
+      --image-refs string            Path to file where a list of the published image references will be written.
+      --insecure-registry            Whether to skip TLS verification on the registry
+  -j, --jobs int                     The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                        Load into images to local docker daemon.
+      --oci-layout-path string       Path to save the OCI image layout of the built images
+      --platform strings             Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+      --posix-capabilities strings   Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER
+  -P, --preserve-import-paths        Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                         Push images to KO_DOCKER_REPO (default true)
+      --sbom string                  The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string              Path to file where the SBOM will be written.
+      --tag-only                     Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                 Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string               File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -112,7 +112,7 @@ done
 popd || exit 1
 
 echo "9. Auto inside the module without vendoring & run with requesteed capabilities should output TEST"
-RESULT="$(GO111MODULE=auto GOFLAGS="" ./ko build --posix-capabilities CAP_IPC_LOCK --local github.com/go-training/helloworld | grep "$FILTER" | xargs -I% docker run --cap-add CAP_IPC_LOCK %)"
+RESULT="$(GO111MODULE=auto GOFLAGS="" ./ko build --cap-add CAP_IPC_LOCK --local github.com/go-training/helloworld | grep "$FILTER" | xargs -I% docker run --cap-add CAP_IPC_LOCK %)"
 if [[ "$RESULT" != *"TEST"* ]]; then
   echo "Test FAILED. Saw $RESULT" && exit 1
 else
@@ -120,7 +120,7 @@ else
 fi
 
 echo "10. Auto inside the module without vendoring & run with too little capabilities should fail"
-(GO111MODULE=auto GOFLAGS="" ./ko build --posix-capabilities CAP_CHOWN --local github.com/go-training/helloworld | grep "$FILTER" | xargs -I% docker run --cap-drop CAP_CHOWN %) && exit 1
+(GO111MODULE=auto GOFLAGS="" ./ko build --cap-add CAP_CHOWN --local github.com/go-training/helloworld | grep "$FILTER" | xargs -I% docker run --cap-drop CAP_CHOWN %) && exit 1
 echo "Test PASSED"
 
 popd || exit 1

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -548,7 +548,7 @@ func tarBinary(name, binary string, platform *v1.Platform, caps []Cap) (*bytes.B
 			"MSWINDOWS.rawsd": userOwnerAndGroupSID,
 		}
 	} else if len(caps) > 0 {
-		// see: https://github.com/testwill/moby/blob/master/pkg/archive/archive.go#L503-L504
+		// see: https://github.com/moby/moby/blob/9b9348ce86fc85798e67319f2b78439408074746/pkg/archive/archive.go#L503-L504
 		header.PAXRecords = map[string]string{
 			"SCHILY.xattr.security.capability": string(capabilityValue(caps)),
 		}

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -177,3 +177,11 @@ func WithSBOMDir(dir string) Option {
 		return nil
 	}
 }
+
+// WithPOSIXCapabilities is a functional option for overriding the POSIX capabilities encoded in the binary file.
+func WithPOSIXCapabilities(capabilities []Cap) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.capabilities = capabilities
+		return nil
+	}
+}

--- a/pkg/build/posixcapability.go
+++ b/pkg/build/posixcapability.go
@@ -19,6 +19,8 @@ import "strings"
 type Cap int
 
 // POSIX-draft defined capabilities.
+// Must be kept in sync with the definitions in https://github.com/containerd/containerd/blob/v1.7.3/pkg/cap/cap_linux.go#L133-L187
+// The values are defined in https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h
 const (
 	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
 	// overrides the restriction of changing file ownership and group
@@ -235,6 +237,45 @@ const (
 
 	// Allow reading audit messages from the kernel
 	CAP_AUDIT_READ = Cap(37)
+
+	// Allow system performance and observability privileged operations
+	// using perf_events, i915_perf and other kernel subsystems
+	CAP_PERFMON = Cap(38)
+
+	// CAP_BPF allows the following BPF operations:
+	// - Creating all types of BPF maps
+	// - Advanced verifier features
+	//   - Indirect variable access
+	//   - Bounded loops
+	//   - BPF to BPF function calls
+	//   - Scalar precision tracking
+	//   - Larger complexity limits
+	//   - Dead code elimination
+	//   - And potentially other features
+	//
+	// - Loading BPF Type Format (BTF) data
+	// - Retrieve xlated and JITed code of BPF programs
+	// - Use bpf_spin_lock() helper
+	//
+	// CAP_PERFMON relaxes the verifier checks further:
+	// - BPF progs can use of pointer-to-integer conversions
+	// - speculation attack hardening measures are bypassed
+	// - bpf_probe_read to read arbitrary kernel memory is allowed
+	// - bpf_trace_printk to print kernel memory is allowed
+	//
+	// CAP_SYS_ADMIN is required to use bpf_probe_write_user.
+	//
+	// CAP_SYS_ADMIN is required to iterate system wide loaded
+	// programs, maps, links, BTFs and convert their IDs to file descriptors.
+	//
+	// CAP_PERFMON and CAP_BPF are required to load tracing programs.
+	// CAP_NET_ADMIN and CAP_BPF are required to load networking programs.
+	CAP_BPF = Cap(39)
+
+	// Allow checkpoint/restore related operations
+	// Allow PID selection during clone3()
+	// Allow writing to ns_last_pid
+	CAP_CHECKPOINT_RESTORE = Cap(40)
 )
 
 func CapFromString(value string) Cap {
@@ -315,6 +356,12 @@ func CapFromString(value string) Cap {
 		return CAP_BLOCK_SUSPEND // 36
 	case "CAP_AUDIT_READ":
 		return CAP_AUDIT_READ // 37
+	case "CAP_PERFMON":
+		return CAP_PERFMON // 38
+	case "CAP_BPF":
+		return CAP_BPF // 39
+	case "CAP_CHECKPOINT_RESTORE":
+		return CAP_CHECKPOINT_RESTORE // 40
 	default:
 		return -1
 	}

--- a/pkg/build/posixcapability.go
+++ b/pkg/build/posixcapability.go
@@ -1,3 +1,17 @@
+// Copyright 2023 ko Build Authors All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package build
 
 import "strings"

--- a/pkg/build/posixcapability.go
+++ b/pkg/build/posixcapability.go
@@ -224,7 +224,7 @@ const (
 	// capability it should use to do so.
 	CAP_MAC_ADMIN = Cap(33)
 
-	// Allow configuring the kernel's syslog (printk behaviour)
+	// Allow configuring the kernel's syslog (printk behavior)
 	CAP_SYSLOG = Cap(34)
 
 	// Allow triggering something that will wake the system

--- a/pkg/build/posixcapability.go
+++ b/pkg/build/posixcapability.go
@@ -1,0 +1,307 @@
+package build
+
+import "strings"
+
+type Cap int
+
+// POSIX-draft defined capabilities.
+const (
+	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
+	// overrides the restriction of changing file ownership and group
+	// ownership.
+	CAP_CHOWN = Cap(0)
+
+	// Override all DAC access, including ACL execute access if
+	// [_POSIX_ACL] is defined. Excluding DAC access covered by
+	// CAP_LINUX_IMMUTABLE.
+	CAP_DAC_OVERRIDE = Cap(1)
+
+	// Overrides all DAC restrictions regarding read and search on files
+	// and directories, including ACL restrictions if [_POSIX_ACL] is
+	// defined. Excluding DAC access covered by CAP_LINUX_IMMUTABLE.
+	CAP_DAC_READ_SEARCH = Cap(2)
+
+	// Overrides all restrictions about allowed operations on files, where
+	// file owner ID must be equal to the user ID, except where CAP_FSETID
+	// is applicable. It doesn't override MAC and DAC restrictions.
+	CAP_FOWNER = Cap(3)
+
+	// Overrides the following restrictions that the effective user ID
+	// shall match the file owner ID when setting the S_ISUID and S_ISGID
+	// bits on that file; that the effective group ID (or one of the
+	// supplementary group IDs) shall match the file owner ID when setting
+	// the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
+	// cleared on successful return from chown(2) (not implemented).
+	CAP_FSETID = Cap(4)
+
+	// Overrides the restriction that the real or effective user ID of a
+	// process sending a signal must match the real or effective user ID
+	// of the process receiving the signal.
+	CAP_KILL = Cap(5)
+
+	// Allows setgid(2) manipulation
+	// Allows setgroups(2)
+	// Allows forged gids on socket credentials passing.
+	CAP_SETGID = Cap(6)
+
+	// Allows set*uid(2) manipulation (including fsuid).
+	// Allows forged pids on socket credentials passing.
+	CAP_SETUID = Cap(7)
+
+	// Linux-specific capabilities
+
+	// Without VFS support for capabilities:
+	//   Transfer any capability in your permitted set to any pid,
+	//   remove any capability in your permitted set from any pid
+	// With VFS support for capabilities (neither of above, but)
+	//   Add any capability from current's capability bounding set
+	//     to the current process' inheritable set
+	//   Allow taking bits out of capability bounding set
+	//   Allow modification of the securebits for a process
+	CAP_SETPCAP = Cap(8)
+
+	// Allow modification of S_IMMUTABLE and S_APPEND file attributes
+	CAP_LINUX_IMMUTABLE = Cap(9)
+
+	// Allows binding to TCP/UDP sockets below 1024
+	// Allows binding to ATM VCIs below 32
+	CAP_NET_BIND_SERVICE = Cap(10)
+
+	// Allow broadcasting, listen to multicast
+	CAP_NET_BROADCAST = Cap(11)
+
+	// Allow interface configuration
+	// Allow administration of IP firewall, masquerading and accounting
+	// Allow setting debug option on sockets
+	// Allow modification of routing tables
+	// Allow setting arbitrary process / process group ownership on
+	// sockets
+	// Allow binding to any address for transparent proxying (also via NET_RAW)
+	// Allow setting TOS (type of service)
+	// Allow setting promiscuous mode
+	// Allow clearing driver statistics
+	// Allow multicasting
+	// Allow read/write of device-specific registers
+	// Allow activation of ATM control sockets
+	CAP_NET_ADMIN = Cap(12)
+
+	// Allow use of RAW sockets
+	// Allow use of PACKET sockets
+	// Allow binding to any address for transparent proxying (also via NET_ADMIN)
+	CAP_NET_RAW = Cap(13)
+
+	// Allow locking of shared memory segments
+	// Allow mlock and mlockall (which doesn't really have anything to do
+	// with IPC)
+	CAP_IPC_LOCK = Cap(14)
+
+	// Override IPC ownership checks
+	CAP_IPC_OWNER = Cap(15)
+
+	// Insert and remove kernel modules - modify kernel without limit
+	CAP_SYS_MODULE = Cap(16)
+
+	// Allow ioperm/iopl access
+	// Allow sending USB messages to any device via /proc/bus/usb
+	CAP_SYS_RAWIO = Cap(17)
+
+	// Allow use of chroot()
+	CAP_SYS_CHROOT = Cap(18)
+
+	// Allow ptrace() of any process
+	CAP_SYS_PTRACE = Cap(19)
+
+	// Allow configuration of process accounting
+	CAP_SYS_PACCT = Cap(20)
+
+	// Allow configuration of the secure attention key
+	// Allow administration of the random device
+	// Allow examination and configuration of disk quotas
+	// Allow setting the domainname
+	// Allow setting the hostname
+	// Allow calling bdflush()
+	// Allow mount() and umount(), setting up new smb connection
+	// Allow some autofs root ioctls
+	// Allow nfsservctl
+	// Allow VM86_REQUEST_IRQ
+	// Allow to read/write pci config on alpha
+	// Allow irix_prctl on mips (setstacksize)
+	// Allow flushing all cache on m68k (sys_cacheflush)
+	// Allow removing semaphores
+	// Used instead of CAP_CHOWN to "chown" IPC message queues, semaphores
+	// and shared memory
+	// Allow locking/unlocking of shared memory segment
+	// Allow turning swap on/off
+	// Allow forged pids on socket credentials passing
+	// Allow setting readahead and flushing buffers on block devices
+	// Allow setting geometry in floppy driver
+	// Allow turning DMA on/off in xd driver
+	// Allow administration of md devices (mostly the above, but some
+	// extra ioctls)
+	// Allow tuning the ide driver
+	// Allow access to the nvram device
+	// Allow administration of apm_bios, serial and bttv (TV) device
+	// Allow manufacturer commands in isdn CAPI support driver
+	// Allow reading non-standardized portions of pci configuration space
+	// Allow DDI debug ioctl on sbpcd driver
+	// Allow setting up serial ports
+	// Allow sending raw qic-117 commands
+	// Allow enabling/disabling tagged queuing on SCSI controllers and sending
+	// arbitrary SCSI commands
+	// Allow setting encryption key on loopback filesystem
+	// Allow setting zone reclaim policy
+	CAP_SYS_ADMIN = Cap(21)
+
+	// Allow use of reboot()
+	CAP_SYS_BOOT = Cap(22)
+
+	// Allow raising priority and setting priority on other (different
+	// UID) processes
+	// Allow use of FIFO and round-robin (realtime) scheduling on own
+	// processes and setting the scheduling algorithm used by another
+	// process.
+	// Allow setting cpu affinity on other processes
+	CAP_SYS_NICE = Cap(23)
+
+	// Override resource limits. Set resource limits.
+	// Override quota limits.
+	// Override reserved space on ext2 filesystem
+	// Modify data journaling mode on ext3 filesystem (uses journaling
+	// resources)
+	// NOTE: ext2 honors fsuid when checking for resource overrides, so
+	// you can override using fsuid too
+	// Override size restrictions on IPC message queues
+	// Allow more than 64hz interrupts from the real-time clock
+	// Override max number of consoles on console allocation
+	// Override max number of keymaps
+	CAP_SYS_RESOURCE = Cap(24)
+
+	// Allow manipulation of system clock
+	// Allow irix_stime on mips
+	// Allow setting the real-time clock
+	CAP_SYS_TIME = Cap(25)
+
+	// Allow configuration of tty devices
+	// Allow vhangup() of tty
+	CAP_SYS_TTY_CONFIG = Cap(26)
+
+	// Allow the privileged aspects of mknod()
+	CAP_MKNOD = Cap(27)
+
+	// Allow taking of leases on files
+	CAP_LEASE = Cap(28)
+
+	CAP_AUDIT_WRITE   = Cap(29)
+	CAP_AUDIT_CONTROL = Cap(30)
+	CAP_SETFCAP       = Cap(31)
+
+	// Override MAC access.
+	// The base kernel enforces no MAC policy.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based overrides of that policy, this is
+	// the capability it should use to do so.
+	CAP_MAC_OVERRIDE = Cap(32)
+
+	// Allow MAC configuration or state changes.
+	// The base kernel requires no MAC configuration.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based checks on modifications to that
+	// policy or the data required to maintain it, this is the
+	// capability it should use to do so.
+	CAP_MAC_ADMIN = Cap(33)
+
+	// Allow configuring the kernel's syslog (printk behaviour)
+	CAP_SYSLOG = Cap(34)
+
+	// Allow triggering something that will wake the system
+	CAP_WAKE_ALARM = Cap(35)
+
+	// Allow preventing system suspends
+	CAP_BLOCK_SUSPEND = Cap(36)
+
+	// Allow reading audit messages from the kernel
+	CAP_AUDIT_READ = Cap(37)
+)
+
+func CapFromString(value string) Cap {
+	switch strings.ToUpper(value) {
+	case "CAP_CHOWN":
+		return CAP_CHOWN // 0
+	case "CAP_DAC_OVERRIDE":
+		return CAP_DAC_OVERRIDE // 1
+	case "CAP_DAC_READ_SEARCH":
+		return CAP_DAC_READ_SEARCH // 2
+	case "CAP_FOWNER":
+		return CAP_FOWNER // 3
+	case "CAP_FSETID":
+		return CAP_FSETID // 4
+	case "CAP_KILL":
+		return CAP_KILL // 5
+	case "CAP_SETGID":
+		return CAP_SETGID // 6
+	case "CAP_SETUID":
+		return CAP_SETUID // 7
+	case "CAP_SETPCAP":
+		return CAP_SETPCAP // 8
+	case "CAP_LINUX_IMMUTABLE":
+		return CAP_LINUX_IMMUTABLE // 9
+	case "CAP_NET_BIND_SERVICE":
+		return CAP_NET_BIND_SERVICE // 10
+	case "CAP_NET_BROADCAST":
+		return CAP_NET_BROADCAST // 11
+	case "CAP_NET_ADMIN":
+		return CAP_NET_ADMIN // 12
+	case "CAP_NET_RAW":
+		return CAP_NET_RAW // 13
+	case "CAP_IPC_LOCK":
+		return CAP_IPC_LOCK // 14
+	case "CAP_IPC_OWNER":
+		return CAP_IPC_OWNER // 15
+	case "CAP_SYS_MODULE":
+		return CAP_SYS_MODULE // 16
+	case "CAP_SYS_RAWIO":
+		return CAP_SYS_RAWIO // 17
+	case "CAP_SYS_CHROOT":
+		return CAP_SYS_CHROOT // 18
+	case "CAP_SYS_PTRACE":
+		return CAP_SYS_PTRACE // 19
+	case "CAP_SYS_PACCT":
+		return CAP_SYS_PACCT // 20
+	case "CAP_SYS_ADMIN":
+		return CAP_SYS_ADMIN // 21
+	case "CAP_SYS_BOOT":
+		return CAP_SYS_BOOT // 22
+	case "CAP_SYS_NICE":
+		return CAP_SYS_NICE // 23
+	case "CAP_SYS_RESOURCE":
+		return CAP_SYS_RESOURCE // 24
+	case "CAP_SYS_TIME":
+		return CAP_SYS_TIME // 25
+	case "CAP_SYS_TTY_CONFIG":
+		return CAP_SYS_TTY_CONFIG // 26
+	case "CAP_MKNOD":
+		return CAP_MKNOD // 27
+	case "CAP_LEASE":
+		return CAP_LEASE // 28
+	case "CAP_AUDIT_WRITE":
+		return CAP_AUDIT_WRITE // 29
+	case "CAP_AUDIT_CONTROL":
+		return CAP_AUDIT_CONTROL // 30
+	case "CAP_SETFCAP":
+		return CAP_SETFCAP // 31
+	case "CAP_MAC_OVERRIDE":
+		return CAP_MAC_OVERRIDE // 32
+	case "CAP_MAC_ADMIN":
+		return CAP_MAC_ADMIN // 33
+	case "CAP_SYSLOG":
+		return CAP_SYSLOG // 34
+	case "CAP_WAKE_ALARM":
+		return CAP_WAKE_ALARM // 35
+	case "CAP_BLOCK_SUSPEND":
+		return CAP_BLOCK_SUSPEND // 36
+	case "CAP_AUDIT_READ":
+		return CAP_AUDIT_READ // 37
+	default:
+		return -1
+	}
+}

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -85,7 +85,7 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
-	cmd.Flags().StringSliceVar(&bo.POSIXCapabilities, "posix-capabilities", []string{},
+	cmd.Flags().StringSliceVar(&bo.POSIXCapabilities, "cap-add", []string{},
 		"Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER")
 	bo.Trimpath = true
 }

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -55,6 +55,7 @@ type BuildOptions struct {
 	SBOMDir              string
 	Platforms            []string
 	Labels               []string
+	POSIXCapabilities    []string
 	// UserAgent enables overriding the default value of the `User-Agent` HTTP
 	// request header used when retrieving the base image.
 	UserAgent string
@@ -84,6 +85,8 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
+	cmd.Flags().StringSliceVar(&bo.POSIXCapabilities, "posix-capabilities", []string{},
+		"Which POSIX capabilities to set on the binary. Eg. CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER")
 	bo.Trimpath = true
 }
 

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -125,6 +125,18 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		opts = append(opts, build.WithSBOMDir(bo.SBOMDir))
 	}
 
+	if bo.POSIXCapabilities != nil {
+		caps := make([]build.Cap, len(bo.POSIXCapabilities))
+		for i, c := range bo.POSIXCapabilities {
+			v := build.CapFromString(c)
+			if v < 0 {
+				return nil, fmt.Errorf("invalid POSIX capability: %q", c)
+			}
+			caps[i] = v
+		}
+		opts = append(opts, build.WithPOSIXCapabilities(caps))
+	}
+
 	return opts, nil
 }
 


### PR DESCRIPTION
To prevent an application from being swapped to disk, we use `mlock` (prevents writing private keys to disk).
However, this requires the POSIX CAP_IPC_LOCK capability to be set on the binary file.
This PR adds the option to specify what capabilities to set on the binary file.

NOTE for reviewer:
Would it be possible to get some feedback on whether this feature would be accepted in ko (regardless of the implementation)?