### PR TITLE
implement dumb cache for images

### DIFF
--- a/pkg/commands/cache.go
+++ b/pkg/commands/cache.go
@@ -1,0 +1,464 @@
+// Copyright 2023 ko Build Authors All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/logs"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/match"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/google/ko/pkg/build"
+)
+
+type imageCache struct {
+	// In memory
+	cache sync.Map
+	p     *layout.Path
+
+	puller *remote.Puller
+}
+
+func newCache(puller *remote.Puller) (*imageCache, error) {
+	cache := &imageCache{
+		puller: puller,
+	}
+	if kc := os.Getenv("KOCACHE"); kc != "" {
+		path := filepath.Join(kc, "img")
+		p, err := layout.FromPath(path)
+		if err != nil {
+			p, err = layout.Write(path, empty.Index)
+			if err != nil {
+				return cache, err
+			}
+		}
+		cache.p = &p
+	}
+
+	return cache, nil
+}
+
+func (i *imageCache) get(ctx context.Context, ref name.Reference, missFunc baseFactory) (build.Result, error) {
+	if v, ok := i.cache.Load(ref.String()); ok {
+		logs.Debug.Printf("cache hit: %s", ref.String())
+
+		return v.(build.Result), nil
+	}
+
+	var (
+		once       sync.Once
+		missResult build.Result
+		missErr    error
+	)
+	miss := func(ctx context.Context, ref name.Reference) (build.Result, error) {
+		once.Do(func() {
+			missResult, missErr = missFunc(ctx, ref)
+		})
+
+		return missResult, missErr
+	}
+
+	if i.p != nil {
+		key := ""
+		if _, ok := ref.(name.Digest); ok {
+			key = ref.Identifier()
+		} else {
+			logs.Debug.Printf("cache miss due to tag: %s", ref.String())
+			result, err := miss(ctx, ref)
+			if err != nil {
+				return result, err
+			}
+
+			dig, err := result.Digest()
+			if err != nil {
+				return result, err
+			}
+
+			key = dig.String()
+		}
+
+		ii, err := i.p.ImageIndex()
+		if err != nil {
+			return nil, err
+		}
+		h, err := v1.NewHash(key)
+		if err != nil {
+			return nil, err
+		}
+		descs, err := partial.FindManifests(ii, match.Digests(h))
+		if err != nil {
+			return nil, err
+		}
+		if len(descs) != 0 {
+			logs.Debug.Printf("cache hit: %s", ref.String())
+			desc := descs[0]
+
+			var br build.Result
+			if desc.MediaType.IsIndex() {
+				idx, err := ii.ImageIndex(h)
+				if err != nil {
+					return nil, err
+				}
+				br, err = i.newLazyIndex(ref, idx, missFunc)
+			} else {
+				img, err := ii.Image(h)
+				if err != nil {
+					return nil, err
+				}
+				br, err = i.newLazyImage(ref, img, missFunc)
+			}
+			if err != nil {
+				return nil, err
+			}
+			i.cache.Store(ref.String(), br)
+			return br, nil
+		}
+	}
+
+	logs.Debug.Printf("cache miss: %s", ref.String())
+	result, err := miss(ctx, ref)
+	if err != nil {
+		return result, err
+	}
+
+	if i.p != nil {
+		logs.Debug.Printf("cache store: %s", ref.String())
+
+		desc, err := partial.Descriptor(result)
+		if err != nil {
+			return result, err
+		}
+
+		manifest, err := result.RawManifest()
+		if err != nil {
+			return result, err
+		}
+
+		if err := i.p.WriteBlob(desc.Digest, io.NopCloser(bytes.NewReader(manifest))); err != nil {
+			return result, err
+		}
+
+		if err := i.p.AppendDescriptor(*desc); err != nil {
+			return result, err
+		}
+
+		if _, ok := result.(v1.ImageIndex); ok {
+			result = &lazyIndex{
+				ref:      ref,
+				desc:     *desc,
+				manifest: manifest,
+				miss:     missFunc,
+				cache:    i,
+			}
+		} else if img, ok := result.(v1.Image); ok {
+			cf, err := img.RawConfigFile()
+			if err != nil {
+				return result, err
+			}
+
+			id, err := img.ConfigName()
+			if err != nil {
+				return result, err
+			}
+
+			if err := i.p.WriteBlob(id, io.NopCloser(bytes.NewReader(cf))); err != nil {
+				return result, err
+			}
+
+			result = &lazyImage{
+				ref:      ref,
+				desc:     *desc,
+				manifest: manifest,
+				config:   cf,
+				id:       id,
+				miss:     missFunc,
+				cache:    i,
+			}
+		}
+	}
+
+	i.cache.Store(ref.String(), result)
+	return result, nil
+}
+
+func (i *imageCache) newLazyIndex(ref name.Reference, idx v1.ImageIndex, missFunc baseFactory) (*lazyIndex, error) {
+	desc, err := partial.Descriptor(idx)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest, err := idx.RawManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	return &lazyIndex{
+		ref:      ref,
+		desc:     *desc,
+		manifest: manifest,
+		miss:     missFunc,
+		cache:    i,
+	}, nil
+}
+
+func (i *imageCache) newLazyImage(ref name.Reference, img v1.Image, missFunc baseFactory) (*lazyImage, error) {
+	desc, err := partial.Descriptor(img)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest, err := img.RawManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	cf, err := img.RawConfigFile()
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := img.ConfigName()
+	if err != nil {
+		return nil, err
+	}
+
+	return &lazyImage{
+		ref:      ref,
+		desc:     *desc,
+		manifest: manifest,
+		config:   cf,
+		id:       id,
+		miss:     missFunc,
+		cache:    i,
+	}, nil
+}
+
+type lazyIndex struct {
+	ref      name.Reference
+	desc     v1.Descriptor
+	manifest []byte
+
+	miss  baseFactory
+	cache *imageCache
+}
+
+func (i *lazyIndex) MediaType() (types.MediaType, error) {
+	return i.desc.MediaType, nil
+}
+
+func (i *lazyIndex) Digest() (v1.Hash, error) {
+	return i.desc.Digest, nil
+}
+
+func (i *lazyIndex) Size() (int64, error) {
+	return i.desc.Size, nil
+}
+
+func (i *lazyIndex) IndexManifest() (*v1.IndexManifest, error) {
+	return v1.ParseIndexManifest(bytes.NewReader(i.manifest))
+}
+
+func (i *lazyIndex) RawManifest() ([]byte, error) {
+	return i.manifest, nil
+}
+
+func (i *lazyIndex) Image(h v1.Hash) (v1.Image, error) {
+	br, err := i.cache.get(context.TODO(), i.ref.Context().Digest(h.String()), i.miss)
+	if err != nil {
+		return nil, fmt.Errorf("Image(%q): %w", h.String(), err)
+	}
+
+	img, ok := br.(v1.Image)
+	if !ok {
+		return nil, fmt.Errorf("Image(%q) is a type %T", h.String(), br)
+	}
+
+	return img, nil
+}
+
+func (i *lazyIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
+	br, err := i.cache.get(context.TODO(), i.ref.Context().Digest(h.String()), i.miss)
+	if err != nil {
+		return nil, err
+	}
+
+	ii, ok := br.(v1.ImageIndex)
+	if !ok {
+		return nil, fmt.Errorf("ImageIndex(%q) is a type %T", h.String(), br)
+	}
+
+	return ii, nil
+}
+
+type lazyImage struct {
+	ref      name.Reference
+	desc     v1.Descriptor
+	manifest []byte
+	config   []byte
+	id       v1.Hash
+
+	miss  baseFactory
+	cache *imageCache
+}
+
+// Layers returns the ordered collection of filesystem layers that comprise this image.
+// The order of the list is oldest/base layer first, and most-recent/top layer last.
+func (i *lazyImage) Layers() ([]v1.Layer, error) {
+	m, err := i.Manifest()
+	if err != nil {
+		return nil, err
+	}
+
+	layers := make([]v1.Layer, 0, len(m.Layers))
+	for _, desc := range m.Layers {
+		diffid, err := partial.BlobToDiffID(i, desc.Digest)
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, &lazyLayer{
+			ref:    i.ref.Context().Digest(desc.Digest.String()),
+			desc:   desc,
+			diffid: diffid,
+			miss:   i.miss,
+			cache:  i.cache,
+		})
+	}
+
+	return layers, nil
+}
+
+func (i *lazyImage) MediaType() (types.MediaType, error) {
+	return i.desc.MediaType, nil
+}
+
+func (i *lazyImage) Digest() (v1.Hash, error) {
+	return i.desc.Digest, nil
+}
+
+func (i *lazyImage) Size() (int64, error) {
+	return i.desc.Size, nil
+}
+
+func (i *lazyImage) ConfigName() (v1.Hash, error) {
+	return i.id, nil
+}
+
+func (i *lazyImage) ConfigFile() (*v1.ConfigFile, error) {
+	return v1.ParseConfigFile(bytes.NewReader(i.config))
+}
+
+func (i *lazyImage) RawConfigFile() ([]byte, error) {
+	return i.config, nil
+}
+
+func (i *lazyImage) Manifest() (*v1.Manifest, error) {
+	return v1.ParseManifest(bytes.NewReader(i.manifest))
+}
+
+func (i *lazyImage) RawManifest() ([]byte, error) {
+	return i.manifest, nil
+}
+
+func (i *lazyImage) LayerByDigest(h v1.Hash) (v1.Layer, error) {
+	if h == i.id {
+		return partial.ConfigLayer(i)
+	}
+
+	layers, err := i.Layers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, layer := range layers {
+		digest, err := layer.Digest()
+		if err != nil {
+			return nil, err
+		}
+
+		if digest == h {
+			return layer, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not find layer %q in lazyImage %q", h.String(), i.ref)
+}
+
+func (i *lazyImage) LayerByDiffID(h v1.Hash) (v1.Layer, error) {
+	d, err := partial.DiffIDToBlob(i, h)
+	if err != nil {
+		return nil, err
+	}
+
+	return i.LayerByDigest(d)
+}
+
+type lazyLayer struct {
+	ref    name.Digest
+	desc   v1.Descriptor
+	diffid v1.Hash
+
+	miss  baseFactory
+	cache *imageCache
+}
+
+func (l *lazyLayer) Digest() (v1.Hash, error) {
+	return l.desc.Digest, nil
+}
+
+func (l *lazyLayer) DiffID() (v1.Hash, error) {
+	return l.diffid, nil
+}
+
+func (l *lazyLayer) Size() (int64, error) {
+	return l.desc.Size, nil
+}
+
+func (l *lazyLayer) MediaType() (types.MediaType, error) {
+	return l.desc.MediaType, nil
+}
+
+func (l *lazyLayer) Compressed() (io.ReadCloser, error) {
+	if rc, err := l.cache.p.Blob(l.desc.Digest); err == nil {
+		return rc, nil
+	}
+
+	rl, err := l.cache.puller.Layer(context.TODO(), l.ref)
+	if err != nil {
+		return nil, err
+	}
+
+	// Note that we intentionally don't cache this because it will slow down cases where registry has it.
+	return rl.Compressed()
+}
+
+func (l *lazyLayer) Uncompressed() (io.ReadCloser, error) {
+	cl, err := partial.CompressedToLayer(l)
+	if err != nil {
+		return nil, err
+	}
+	return cl.Uncompressed()
+}


### PR DESCRIPTION
This speeds up repeated builds by caching manifests and config files locally under `${KOCACHE}/img`.
Before:

```
ko build .  1.09s user 2.37s system 148% cpu 2.326 total
```

After:

```
ko build .  1.05s user 2.29s system 244% cpu 1.366 total
```

(Most of the time difference comes from not having to do the TLS handshake with DockerHub to fetch the golang stuff.)

This has a nice effect of allowing offline builds with `ko` if your base images are referenced by digest _and_ you pre-pull the images into `${KOCACHE}/img`.

This does not cache base image layers by default because they are often present in the destination registry and would slow things down and take up space.

It might make sense to add a command or flag to completely cache the base image, but we could also just add some docs about how to pull it off with crane, e.g. for ko:

```
$ crane pull --format oci golang:1.20 $KOCACHE/img
```

Then modifying the `.ko.yaml` file to be:

```
baseImageOverrides:
  github.com/google/ko: golang:1.20@sha256:cfc9d1b07b1ef4f7a4571f0b60a99646a92ef76adb7d9943f4cb7b606c6554e2
```

If we `--push=false`, we don't hit the network at all:

```
time ko build -v . --push=false
2023/07/27 14:37:32 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
2023/07/27 14:37:32 cache hit: golang:1.20@sha256:cfc9d1b07b1ef4f7a4571f0b60a99646a92ef76adb7d9943f4cb7b606c6554e2
2023/07/27 14:37:32 Using base golang:1.20@sha256:cfc9d1b07b1ef4f7a4571f0b60a99646a92ef76adb7d9943f4cb7b606c6554e2 for github.com/google/ko
2023/07/27 14:37:32 cache hit: index.docker.io/library/golang@sha256:832f2f74baa3e2b00ace688cb2fa934dffeade39f5b4c0cc8b1cff8d3fb084a0
2023/07/27 14:37:32 Using build config ko for github.com/google/ko
2023/07/27 14:37:32 Building github.com/google/ko for linux/amd64
us-central1-docker.pkg.dev/jonjohnson-chainguard/ko/ko-98b8c7facdad74510a7cae0cd368eb4e:latest@sha256:3609cb6560c07a6f2cff054efbf962860e35e89cfa495a85cbf71e71c9e99445
ko build -v . --push=false  0.96s user 2.17s system 573% cpu 0.546 total
```