### PR TITLE
Allow using go test -c as build command

### DIFF
--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -66,6 +66,7 @@ ko apply -f FILENAME [flags]
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
       --tarball string           File to save images tarballs
+      --test                     Use go test -c instead of go build when building Go code.
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -60,6 +60,7 @@ ko build IMPORTPATH... [flags]
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
       --tarball string           File to save images tarballs
+      --test                     Use go test -c instead of go build when building Go code.
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -66,6 +66,7 @@ ko create -f FILENAME [flags]
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
       --tarball string           File to save images tarballs
+      --test                     Use go test -c instead of go build when building Go code.
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -59,6 +59,7 @@ ko resolve -f FILENAME [flags]
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
       --tarball string           File to save images tarballs
+      --test                     Use go test -c instead of go build when building Go code.
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -48,6 +48,7 @@ ko run IMPORTPATH [flags]
       --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
       --tarball string           File to save images tarballs
+      --test                     Use go test -c instead of go build when building Go code.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/build/gobuilds.go
+++ b/pkg/build/gobuilds.go
@@ -32,6 +32,9 @@ type gobuilds struct {
 
 	// workingDirectory is typically ".", but it may be a different value if ko is embedded as a library.
 	workingDirectory string
+
+	// ignore supported reference
+	ignoreSupportedReference bool
 }
 
 // builderWithConfig is not an imaginative name.

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -177,3 +177,11 @@ func WithSBOMDir(dir string) Option {
 		return nil
 	}
 }
+
+// WithCreateTestBinary is a functional option for overriding the go option
+func WithCreateTestBinary(createTestBinary bool) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.createTestBinary = createTestBinary
+		return nil
+	}
+}

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -69,6 +69,9 @@ type BuildOptions struct {
 
 	// BuildConfigs stores the per-image build config from `.ko.yaml`.
 	BuildConfigs map[string]build.Config
+
+	// compile the test binary
+	CreateTestBinary bool
 }
 
 func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
@@ -84,6 +87,9 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
+	cmd.Flags().BoolVar(&bo.CreateTestBinary, "test", bo.CreateTestBinary,
+		"Use go test -c instead of go build when building Go code.")
+
 	bo.Trimpath = true
 }
 

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -126,6 +126,9 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		opts = append(opts, build.WithSBOMDir(bo.SBOMDir))
 	}
 
+	if bo.CreateTestBinary {
+		opts = append(opts, build.WithCreateTestBinary(bo.CreateTestBinary))
+	}
 	return opts, nil
 }
 


### PR DESCRIPTION
https://github.com/ko-build/ko/issues/96
This isssue has been stopped, but I made a preliminary draft.

```
ko build --test import-path
```
will use go test -c instead of go build.