### PR TITLE
ci: add govulncheck

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,8 @@ jobs:
           go-version: ${{ matrix.go-version }}
           check-latest: true
 
+      - uses: golang/govulncheck-action@dd3ead030e4f2cf713062f7a3395191802364e13 # v1
+
       - run: |
           go build ./...
           go test -run=^$ ./...


### PR DESCRIPTION
https://github.com/golang/govulncheck-action

```
govulncheck ./...        
govulncheck is an experimental tool. Share feedback at https://go.dev/s/govulncheck-feedback.

Using go1.20.7
 and govulncheck@v0.2.0 with vulnerability data from https://vuln.go.dev (last modified 2023-08-02 20:33:39 +0000 UTC).

Scanning your code and 658 packages across 111 dependent modules for known vulnerabilities...
```

(no vulns 😎)