### PR TITLE
docs: rephrase the description for '--local' CLI flag

### DIFF
--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -54,7 +54,7 @@ ko apply -f FILENAME [flags]
       --image-refs string        Path to file where a list of the published image references will be written.
       --insecure-registry        Whether to skip TLS verification on the registry
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
+  -L, --local                    Load images into a local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.

--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -54,7 +54,7 @@ ko apply -f FILENAME [flags]
       --image-refs string        Path to file where a list of the published image references will be written.
       --insecure-registry        Whether to skip TLS verification on the registry
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load images into a local docker daemon.
+  -L, --local                    Push images into a local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -50,7 +50,7 @@ ko build IMPORTPATH... [flags]
       --image-refs string        Path to file where a list of the published image references will be written.
       --insecure-registry        Whether to skip TLS verification on the registry
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
+  -L, --local                    Load images into a local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -50,7 +50,7 @@ ko build IMPORTPATH... [flags]
       --image-refs string        Path to file where a list of the published image references will be written.
       --insecure-registry        Whether to skip TLS verification on the registry
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load images into a local docker daemon.
+  -L, --local                    Push images into a local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -54,7 +54,7 @@ ko create -f FILENAME [flags]
       --image-refs string        Path to file where a list of the published image references will be written.
       --insecure-registry        Whether to skip TLS verification on the registry
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load images into a local docker daemon.
+  -L, --local                    Push images into a local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -54,7 +54,7 @@ ko create -f FILENAME [flags]
       --image-refs string        Path to file where a list of the published image references will be written.
       --insecure-registry        Whether to skip TLS verification on the registry
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
+  -L, --local                    Load images into a local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -47,7 +47,7 @@ ko resolve -f FILENAME [flags]
       --image-refs string        Path to file where a list of the published image references will be written.
       --insecure-registry        Whether to skip TLS verification on the registry
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
+  -L, --local                    Load images into a local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -47,7 +47,7 @@ ko resolve -f FILENAME [flags]
       --image-refs string        Path to file where a list of the published image references will be written.
       --insecure-registry        Whether to skip TLS verification on the registry
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load images into a local docker daemon.
+  -L, --local                    Push images into a local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -38,7 +38,7 @@ ko run IMPORTPATH [flags]
       --image-refs string        Path to file where a list of the published image references will be written.
       --insecure-registry        Whether to skip TLS verification on the registry
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load images into a local docker daemon.
+  -L, --local                    Push images into a local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -38,7 +38,7 @@ ko run IMPORTPATH [flags]
       --image-refs string        Path to file where a list of the published image references will be written.
       --insecure-registry        Whether to skip TLS verification on the registry
   -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
+  -L, --local                    Load images into a local docker daemon.
       --oci-layout-path string   Path to save the OCI image layout of the built images
       --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
   -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.

--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -88,7 +88,7 @@ func AddPublishArg(cmd *cobra.Command, po *PublishOptions) {
 	cmd.Flags().BoolVar(&po.Push, "push", true, "Push images to KO_DOCKER_REPO")
 
 	cmd.Flags().BoolVarP(&po.Local, "local", "L", po.Local,
-		"Load images into a local docker daemon.")
+		"Push images into a local docker daemon.")
 	cmd.Flags().BoolVar(&po.InsecureRegistry, "insecure-registry", po.InsecureRegistry,
 		"Whether to skip TLS verification on the registry")
 

--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -88,7 +88,7 @@ func AddPublishArg(cmd *cobra.Command, po *PublishOptions) {
 	cmd.Flags().BoolVar(&po.Push, "push", true, "Push images to KO_DOCKER_REPO")
 
 	cmd.Flags().BoolVarP(&po.Local, "local", "L", po.Local,
-		"Load into images to local docker daemon.")
+		"Load images into a local docker daemon.")
 	cmd.Flags().BoolVar(&po.InsecureRegistry, "insecure-registry", po.InsecureRegistry,
 		"Whether to skip TLS verification on the registry")
 


### PR DESCRIPTION
As I was reading the description for the `ko build --help` flags, I was slightly confused with the text for the `local` flag and wanted to propose an alternative:

Before: 
```
-L, --local Load into images to local docker daemon.
```

After: 
```
-L, --local Push images into a local docker daemon.
```

From [the source code](https://github.com/ko-build/ko/blob/d4a1cc961c9064e9fd616ab39a9ace6cafacf2cd/pkg/commands/resolver.go#L187) it seems the flag is only used to derive repo name for the push.

I wasn't sure if the exact term is "Push" or "Publish" (as appears in the command description). Since the command also use a `--push` flag I choose "Push" but maybe "Publish" is more accurate? The flag seems to [reside in](https://github.com/ko-build/ko/blob/d4a1cc961c9064e9fd616ab39a9ace6cafacf2cd/pkg/commands/options/publish.go#L54) `type PublishOptions struct {` which refers to publishing.

I hope it makes sense. If you prefer the current wording better, please feel free to close the PR.

Thank you