### PR TITLE
include go build output in build error

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -312,8 +312,7 @@ func build(ctx context.Context, ip string, dir string, platform v1.Platform, con
 		if os.Getenv("KOCACHE") == "" {
 			os.RemoveAll(tmpDir)
 		}
-		log.Printf("Unexpected error running \"go build\": %v\n%v", err, output.String())
-		return "", fmt.Errorf("go build: %w", err)
+		return "", fmt.Errorf("go build: %w: %s", err, output.String())
 	}
 	return file, nil
 }


### PR DESCRIPTION
This doesn't change much for users of `ko` as a CLI, the output still contains relevant error output:

```
$ go run ./ build ./test/                                 
2023/09/07 09:18:11 Using base cgr.dev/chainguard/static:latest@sha256:a432665213f109d5e48111316030eecc5191654cf02a5b66ac6c5d6b310a5511 for github.com/google/ko/test
2023/09/07 09:18:11 Building github.com/google/ko/test for linux/amd64
Error: failed to publish images: error building "ko://github.com/google/ko/test": build: go build: exit status 1: # github.com/google/ko/test
test/main.go:80:1: syntax error: non-declaration statement outside function body
```

Previously, this was:

```
ko build ./test/
2023/09/07 09:19:21 Using base cgr.dev/chainguard/static:latest@sha256:a432665213f109d5e48111316030eecc5191654cf02a5b66ac6c5d6b310a5511 for github.com/google/ko/test
2023/09/07 09:19:22 Building github.com/google/ko/test for linux/amd64
2023/09/07 09:19:22 Unexpected error running "go build": exit status 1
# github.com/google/ko/test
test/main.go:79:1: syntax error: non-declaration statement outside function body
Error: failed to publish images: error building "ko://github.com/google/ko/test": build: go build: exit status 1
exit status 1
```

For users of `ko` as a library, mainly [tf-ko](https://ko.build/terraform), which swallows log output, this will be very helpful in surfacing the `go build` error.