### PR TITLE
Allow specifying binary path in image

### DIFF
--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -47,6 +47,7 @@ ko apply -f FILENAME [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --binary string            Set to override binary path in image.
       --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -f, --filename strings         Filename, directory, or URL to files to use to create the resource

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -44,6 +44,7 @@ ko build IMPORTPATH... [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --binary string            Set to override binary path in image.
       --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -h, --help                     help for build

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -47,6 +47,7 @@ ko create -f FILENAME [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --binary string            Set to override binary path in image.
       --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -f, --filename strings         Filename, directory, or URL to files to use to create the resource

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -40,6 +40,7 @@ ko resolve -f FILENAME [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --binary string            Set to override binary path in image.
       --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -f, --filename strings         Filename, directory, or URL to files to use to create the resource

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -32,6 +32,7 @@ ko run IMPORTPATH [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --binary string            Set to override binary path in image.
       --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -h, --help                     help for run

--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -79,6 +79,9 @@ type Config struct {
 	// Env allows setting environment variables for `go build`
 	Env []string `yaml:",omitempty"`
 
+	// Binary allows overriding the output binary name (in the image)
+	Binary string `yaml:",omitempty"`
+
 	// Other GoReleaser fields that are not supported or do not make sense
 	// in the context of ko, for reference or for future use:
 	// Goos         []string    `yaml:",omitempty"`
@@ -86,7 +89,6 @@ type Config struct {
 	// Goarm        []string    `yaml:",omitempty"`
 	// Gomips       []string    `yaml:",omitempty"`
 	// Targets      []string    `yaml:",omitempty"`
-	// Binary       string      `yaml:",omitempty"`
 	// Lang         string      `yaml:",omitempty"`
 	// Asmflags     StringArray `yaml:",omitempty"`
 	// Gcflags      StringArray `yaml:",omitempty"`

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -92,6 +92,7 @@ type gobuild struct {
 	build                builder
 	sbom                 sbomber
 	sbomDir              string
+	binaryPath           string
 	disableOptimizations bool
 	trimpath             bool
 	buildConfigs         map[string]Config
@@ -118,6 +119,7 @@ type gobuildOpener struct {
 	build                builder
 	sbom                 sbomber
 	sbomDir              string
+	binaryPath           string
 	disableOptimizations bool
 	trimpath             bool
 	buildConfigs         map[string]Config
@@ -150,6 +152,7 @@ func (gbo *gobuildOpener) Open() (Interface, error) {
 		build:                gbo.build,
 		sbom:                 gbo.sbom,
 		sbomDir:              gbo.sbomDir,
+		binaryPath:           gbo.binaryPath,
 		disableOptimizations: gbo.disableOptimizations,
 		trimpath:             gbo.trimpath,
 		buildConfigs:         gbo.buildConfigs,
@@ -928,6 +931,10 @@ func (g *gobuild) configForImportPath(ip string) Config {
 	if g.disableOptimizations {
 		// Disable optimizations (-N) and inlining (-l).
 		config.Flags = append(config.Flags, "-gcflags", "all=-N -l")
+	}
+
+	if g.binaryPath != "" {
+		config.Binary = g.binaryPath
 	}
 
 	if config.ID != "" {

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -496,6 +496,16 @@ func TestBuildConfig(t *testing.T) {
 				Flags: FlagArray{"-gcflags", "all=-N -l"},
 			},
 		},
+		{
+			description: "override binary path",
+			options: []Option{
+				WithBaseImages(nilGetBase),
+				WithBinaryPath("/mydir/myprogram"),
+			},
+			expectConfig: Config{
+				Binary: "/mydir/myprogram",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -191,3 +191,12 @@ func WithDebugger() Option {
 		return nil
 	}
 }
+
+// WithBinaryPath is a functional option for overriding the path
+// to the executable in the output image.
+func WithBinaryPath(binaryPath string) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.binaryPath = binaryPath
+		return nil
+	}
+}

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -78,6 +78,9 @@ type BuildOptions struct {
 	// `AddBuildOptions()` defaults this field to `true`.
 	Trimpath bool
 
+	// BinaryPath overrides the default path for the binary in the output image.
+	BinaryPath string
+
 	// BuildConfigs stores the per-image build config from `.ko.yaml`.
 	BuildConfigs map[string]build.Config
 }
@@ -93,6 +96,8 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Path to file where the SBOM will be written.")
 	cmd.Flags().StringSliceVar(&bo.Platforms, "platform", []string{},
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
+	cmd.Flags().StringVar(&bo.BinaryPath, "binary", "",
+		"Set to override binary path in image.")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
 	cmd.Flags().BoolVar(&bo.Debug, "debug", bo.Debug,

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -128,6 +128,10 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		opts = append(opts, build.WithSBOMDir(bo.SBOMDir))
 	}
 
+	if bo.BinaryPath != "" {
+		opts = append(opts, build.WithBinaryPath(bo.BinaryPath))
+	}
+
 	return opts, nil
 }
 


### PR DESCRIPTION
Previously this was hard-coded to `/ko-app/<app-name>`.

go-releaser allows specifying the binary (including directory prefix);
we now support the same.
