### PR TITLE
Use go1.21, clean up ci and drop go1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
-- package-ecosystem: "gomod"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: weekly
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,8 @@ name: Build
 
 on:
   pull_request:
-    branches: ['main']
+    branches:
+      - 'main'
 
 jobs:
 
@@ -10,7 +11,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.19', '1.20']
+        go-version:
+          - '1.20'
+          - '1.21'
+
     name: Build ${{ matrix.go-version }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,8 @@ jobs:
           check-latest: true
 
       - uses: golang/govulncheck-action@dd3ead030e4f2cf713062f7a3395191802364e13 # v1
+        with:
+          go-version-input: ${{ matrix.go-version }}
 
       - run: |
           go build ./...

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,7 +29,9 @@ jobs:
         KO_DOCKER_REPO: ko.local
       shell: bash
       run: |
-        set -euxo pipefail
+        set -o errexit
+        set -o nounset
+        set -o pipefail
 
         # eval `go env`, compatible with Windows and Linux
         # cribbed from https://gist.github.com/Syeberman/39d81b1e17d091be5657ecd6fbff0753

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,7 +2,8 @@ name: Basic e2e test
 
 on:
   pull_request:
-    branches: ['main']
+    branches:
+      - 'main'
 
 jobs:
   e2e:
@@ -12,6 +13,7 @@ jobs:
         platform:
         - ubuntu-latest
         - windows-latest
+
     name: e2e ${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}
 
@@ -19,7 +21,7 @@ jobs:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: '1.20'
+        go-version: '1.21'
         check-latest: true
 
     - name: Build and run ko container

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -2,7 +2,8 @@ name: image
 
 on:
   push:
-    branches: ['main']
+    branches:
+      - 'main'
   workflow_dispatch:
 
 permissions:
@@ -17,7 +18,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
 

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -3,7 +3,8 @@ name: KinD e2e tests
 on:
   workflow_dispatch:  # Allow manual runs.
   pull_request:
-    branches: ['main']
+    branches:
+      - 'main'
 
 jobs:
   e2e-tests:
@@ -20,7 +21,7 @@ jobs:
     steps:
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: '1.20'
+        go-version: '1.21'
         check-latest: true
 
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -31,7 +32,7 @@ jobs:
     - name: Setup Cluster
       uses: chainguard-dev/actions/setup-kind@84c993eaf02da1c325854fb272a4df9184bd80fc # main
       with:
-        k8s-version: v1.23.x
+        k8s-version: v1.25.x
         registry-authority: ${{ env.REGISTRY_NAME }}:${{ env.REGISTRY_PORT }}
 
     - name: Install Cosign

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -30,7 +30,7 @@ jobs:
       run: go install ./
 
     - name: Setup Cluster
-      uses: chainguard-dev/actions/setup-kind@84c993eaf02da1c325854fb272a4df9184bd80fc # main
+      uses: chainguard-dev/actions/setup-kind@81dc0f9b6cd749004a9567afffef41ea84cf954c # main
       with:
         k8s-version: v1.25.x
         registry-authority: ${{ env.REGISTRY_NAME }}:${{ env.REGISTRY_PORT }}

--- a/.github/workflows/modules-integration-test.yaml
+++ b/.github/workflows/modules-integration-test.yaml
@@ -2,14 +2,17 @@ name: Integration Test
 
 on:
   pull_request:
-    branches: ['main']
+    branches:
+      - 'main'
 
 jobs:
   test:
     name: Module Tests
     strategy:
       matrix:
-        go-version: ['1.19', '1.20']
+        go-version:
+          - '1.20'
+          - '1.21'
 
     runs-on: 'ubuntu-latest'
     steps:

--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -2,7 +2,8 @@ name: publish
 on:
   workflow_dispatch:
   push:
-    branches: ['main']
+    branches:
+      - 'main'
 
 jobs:
   publish:

--- a/.github/workflows/registries.yaml
+++ b/.github/workflows/registries.yaml
@@ -2,7 +2,8 @@ name: Push to registries
 
 on:
   push:
-    branches: ['main']
+    branches:
+      - 'main'
 
   workflow_dispatch:  # Allow manual runs.
 
@@ -15,7 +16,7 @@ jobs:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: '1.20'
+        go-version: '1.21'
         check-latest: true
     - env:
         QUAY_USERNAME: ko-testing+test
@@ -33,7 +34,7 @@ jobs:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: '1.20'
+        go-version: '1.21'
         check-latest: true
     - env:
         DOCKERHUB_USERNAME: kotesting
@@ -63,7 +64,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - name: Install ko

--- a/.github/workflows/registries.yaml
+++ b/.github/workflows/registries.yaml
@@ -1,8 +1,6 @@
 name: Push to registries
 
 on:
-  pull_request_target:
-    branches: ['main']
   push:
     branches: ['main']
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
 
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       # This installs the current latest release.
       - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
         with:
-          version: v0.13.0
+          version: v0.14.1
 
       - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
 

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -2,7 +2,8 @@ name: Validate SBOMs
 
 on:
   pull_request:
-    branches: ['main']
+    branches:
+      - 'main'
 
 env:
   SPDX_TOOLS_VERSION: 1.1.0
@@ -18,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: chainguard-dev/actions/setup-registry@main
       - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
@@ -82,7 +83,7 @@ jobs:
     steps:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: chainguard-dev/actions/setup-registry@main
       - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -2,7 +2,8 @@ name: Code Style
 
 on:
   pull_request:
-    branches: ['main']
+    branches:
+      - 'main'
 
 jobs:
 
@@ -12,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - uses: chainguard-dev/actions/gofmt@d886686603afb809f7ef9b734b333e20b7ce5cda
@@ -25,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - uses: chainguard-dev/actions/goimports@d886686603afb809f7ef9b734b333e20b7ce5cda
@@ -38,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - name: Check out code

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,11 @@ name: Test
 
 on:
   push:
-    branches: ['main']
+    branches:
+      - 'main'
   pull_request:
-    branches: ['main']
+    branches:
+      - 'main'
 
 jobs:
 
@@ -16,7 +18,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - run: go test -coverprofile=coverage.txt -covermode=atomic -race ./...

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -17,3 +17,18 @@ jobs:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - name: Verify
       run: ./hack/presubmit.sh
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: '1.21'
+          check-latest: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+        with:
+          version: v1.54
+          args: --timeout=5m

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,7 +2,8 @@ name: Verify
 
 on:
   pull_request:
-    branches: ['main']
+    branches:
+      - 'main'
 
 jobs:
   verify:
@@ -11,7 +12,7 @@ jobs:
     steps:
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: '1.20'
+        go-version: '1.21'
         check-latest: true
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - name: Verify

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,7 +1,7 @@
 baseImageOverrides:
-  github.com/google/ko: golang:1.20
+  github.com/google/ko: golang:1.21
 
 builds:
-- id: ko
-  ldflags:
-  - "{{ .Env.LDFLAGS }}"
+  - id: ko
+    ldflags:
+      - "{{ .Env.LDFLAGS }}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/ko
 
-go 1.19
+go 1.20
 
 require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220517224237-e6f29200ae04


### PR DESCRIPTION
- remove pull_request-target and make registry job only postsubmit
- update config for dependabot
- drop go1.19, use go1.21 as default for ci and release
- add golangci-lint job
- use go1.21 as base image
- update go module to require minimum go1.20