### PR TITLE
Introduce `--disable-entrypoint-overwrite` option to allow to disable entrypoint overwrite

### DIFF
--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -45,27 +45,28 @@ ko apply -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for apply
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                           Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths              Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-entrypoint-overwrite   Disable overwriting the images ENTRYPOINT and keep it from the base image.
+      --disable-optimizations          Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings               Filename, directory, or URL to files to use to create the resource
+  -h, --help                           help for apply
+      --image-label strings            Which labels (key=value) to add to the image.
+      --image-refs string              Path to file where a list of the published image references will be written.
+      --insecure-registry              Whether to skip TLS verification on the registry
+  -j, --jobs int                       The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                          Load into images to local docker daemon.
+      --oci-layout-path string         Path to save the OCI image layout of the built images
+      --platform strings               Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths          Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                           Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                      Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string                Path to file where the SBOM will be written.
+  -l, --selector string                Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                       Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                   Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string                 File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -42,24 +42,25 @@ ko build IMPORTPATH... [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -h, --help                     help for build
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                           Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths              Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-entrypoint-overwrite   Disable overwriting the images ENTRYPOINT and keep it from the base image.
+      --disable-optimizations          Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                           help for build
+      --image-label strings            Which labels (key=value) to add to the image.
+      --image-refs string              Path to file where a list of the published image references will be written.
+      --insecure-registry              Whether to skip TLS verification on the registry
+  -j, --jobs int                       The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                          Load into images to local docker daemon.
+      --oci-layout-path string         Path to save the OCI image layout of the built images
+      --platform strings               Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths          Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                           Push images to KO_DOCKER_REPO (default true)
+      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string                Path to file where the SBOM will be written.
+      --tag-only                       Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                   Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string                 File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -45,27 +45,28 @@ ko create -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for create
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                           Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths              Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-entrypoint-overwrite   Disable overwriting the images ENTRYPOINT and keep it from the base image.
+      --disable-optimizations          Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings               Filename, directory, or URL to files to use to create the resource
+  -h, --help                           help for create
+      --image-label strings            Which labels (key=value) to add to the image.
+      --image-refs string              Path to file where a list of the published image references will be written.
+      --insecure-registry              Whether to skip TLS verification on the registry
+  -j, --jobs int                       The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                          Load into images to local docker daemon.
+      --oci-layout-path string         Path to save the OCI image layout of the built images
+      --platform strings               Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths          Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                           Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                      Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string                Path to file where the SBOM will be written.
+  -l, --selector string                Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                       Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                   Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string                 File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -38,27 +38,28 @@ ko resolve -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for resolve
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                           Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths              Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-entrypoint-overwrite   Disable overwriting the images ENTRYPOINT and keep it from the base image.
+      --disable-optimizations          Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings               Filename, directory, or URL to files to use to create the resource
+  -h, --help                           help for resolve
+      --image-label strings            Which labels (key=value) to add to the image.
+      --image-refs string              Path to file where a list of the published image references will be written.
+      --insecure-registry              Whether to skip TLS verification on the registry
+  -j, --jobs int                       The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                          Load into images to local docker daemon.
+      --oci-layout-path string         Path to save the OCI image layout of the built images
+      --platform strings               Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths          Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                           Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                      Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string                Path to file where the SBOM will be written.
+  -l, --selector string                Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                       Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                   Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string                 File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -30,24 +30,25 @@ ko run IMPORTPATH [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -h, --help                     help for run
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                           Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths              Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-entrypoint-overwrite   Disable overwriting the images ENTRYPOINT and keep it from the base image.
+      --disable-optimizations          Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                           help for run
+      --image-label strings            Which labels (key=value) to add to the image.
+      --image-refs string              Path to file where a list of the published image references will be written.
+      --insecure-registry              Whether to skip TLS verification on the registry
+  -j, --jobs int                       The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                          Load into images to local docker daemon.
+      --oci-layout-path string         Path to save the OCI image layout of the built images
+      --platform strings               Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths          Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                           Push images to KO_DOCKER_REPO (default true)
+      --sbom string                    The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string                Path to file where the SBOM will be written.
+      --tag-only                       Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings                   Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string                 File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -908,6 +908,7 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 
 		updatePath(cfg, `C:\ko-app`)
 		cfg.Config.Env = append(cfg.Config.Env, `KO_DATA_PATH=C:\var\run\ko`)
+		cfg.Config.Env = append(cfg.Config.Env, `KO_APP_PATH=C:\ko-app\`+appFileName)
 	} else {
 		if !g.disableEntrypointOverwrite {
 			cfg.Config.Entrypoint = []string{appPath}
@@ -915,6 +916,7 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 
 		updatePath(cfg, appDir)
 		cfg.Config.Env = append(cfg.Config.Env, "KO_DATA_PATH="+kodataRoot)
+		cfg.Config.Env = append(cfg.Config.Env, "KO_APP_PATH="+appPath)
 	}
 	cfg.Author = "github.com/ko-build/ko"
 

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -669,6 +669,23 @@ func validateImage(t *testing.T, img oci.SignedImage, baseLayers int64, creation
 		}
 	})
 
+	// Check that the environment contains the KO_APP_PATH environment variable.
+	t.Run("check KO_APP_PATH env var", func(t *testing.T) {
+		cfg, err := img.ConfigFile()
+		if err != nil {
+			t.Errorf("ConfigFile() = %v", err)
+		}
+		found := false
+		for _, entry := range cfg.Config.Env {
+			if entry == "KO_APP_PATH=/ko-app/test" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("Didn't find KO_APP_PATH.")
+		}
+	})
+
 	// Check that PATH contains the directory of the produced binary.
 	t.Run("check PATH env var", func(t *testing.T) {
 		cfg, err := img.ConfigFile()

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -177,3 +177,10 @@ func WithSBOMDir(dir string) Option {
 		return nil
 	}
 }
+
+func WithDisabledEntrypointOverwrite() Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.disableEntrypointOverwrite = true
+		return nil
+	}
+}

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -49,12 +49,13 @@ type BuildOptions struct {
 	// Empty string means the current working directory.
 	WorkingDirectory string
 
-	ConcurrentBuilds     int
-	DisableOptimizations bool
-	SBOM                 string
-	SBOMDir              string
-	Platforms            []string
-	Labels               []string
+	ConcurrentBuilds           int
+	DisableOptimizations       bool
+	SBOM                       string
+	SBOMDir                    string
+	Platforms                  []string
+	Labels                     []string
+	DisableEntrypointOverwrite bool
 	// UserAgent enables overriding the default value of the `User-Agent` HTTP
 	// request header used when retrieving the base image.
 	UserAgent string
@@ -84,6 +85,8 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
+	cmd.Flags().BoolVar(&bo.DisableEntrypointOverwrite, "disable-entrypoint-overwrite", bo.DisableEntrypointOverwrite,
+		"Disable overwriting the images ENTRYPOINT and keep it from the base image.")
 	bo.Trimpath = true
 }
 

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -125,6 +125,10 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		opts = append(opts, build.WithSBOMDir(bo.SBOMDir))
 	}
 
+	if bo.DisableEntrypointOverwrite {
+		opts = append(opts, build.WithDisabledEntrypointOverwrite())
+	}
+
 	return opts, nil
 }
 


### PR DESCRIPTION
Currently the entrypoint of the image is always set to `/ko-app/<app-name>`. This makes it hard to have some kind of wrapper around the app (e.g. in case you want to remote debug the app via Delve, which invokes the app e.g. via `dlv exec <path-to-app>`).

This PR addresses it and introduces a new option (`--disable-entrypoint-overwrite`), which allows to use the entrypoint of the base image. To be able to get the path to the apps binary, this PR also introduce the `KO_APP_PATH` var, which points to the apps binary.
That way a developer who wants to remote debug their app (without to adjust yamls with an updated command & arg) could simply use a base image with a pre setup entrypoint, like the following:

```
ENTRYPOINT "/usr/bin/dlv exec --listen=:40000 --headless=true --log=true --accept-multiclient --api-version=2 $APP_PATH"
```
and build/apply via:
```
ko apply apply --disable-entrypoint-overwrite --disable-optimizations -f <path-to-yaml>
```