### PR TITLE
Update e2e.yaml

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
-        go-version: '1.21'
+        go-version: '1.20'
         check-latest: true
 
     - name: Build and run ko container


### PR DESCRIPTION
The e2e tests fail with some quoting issue, let's see if it's due to 1.21

```
platform is 'linux'/'amd64',linux/arm64
```

https://github.com/ko-build/ko/actions/runs/6146667632/job/16676493935?pr=1139