### PR TITLE
handle newfound lint errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,8 +10,6 @@ issues:
 linters:
   enable:
   - asciicheck
-  - deadcode
-  - depguard
   - errorlint
   - gofmt
   - gosec
@@ -28,3 +26,5 @@ linters:
 
   disable:
   - errcheck
+  - depguard
+  - deadcode

--- a/internal/sbom/cyclonedx.go
+++ b/internal/sbom/cyclonedx.go
@@ -126,7 +126,7 @@ func GenerateImageCycloneDX(mod []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func GenerateIndexCycloneDX(sii oci.SignedImageIndex) ([]byte, error) {
+func GenerateIndexCycloneDX(oci.SignedImageIndex) ([]byte, error) {
 	return nil, nil
 }
 

--- a/pkg/build/cache.go
+++ b/pkg/build/cache.go
@@ -48,14 +48,14 @@ func (c *layerCache) get(ctx context.Context, file string, miss layerFactory) (v
 	}
 
 	// Cache hit.
-	if diffid, desc, err := c.getMeta(ctx, file); err == nil {
+	if diffid, desc, err := c.getMeta(ctx, file); err != nil {
+		logs.Debug.Printf("getMeta(%q): %v", file, err)
+	} else {
 		return &lazyLayer{
 			diffid:     *diffid,
 			desc:       *desc,
 			buildLayer: miss,
 		}, nil
-	} else {
-		logs.Debug.Printf("getMeta(%q): %v", file, err)
 	}
 
 	// Cache miss.
@@ -158,11 +158,7 @@ func (c *layerCache) put(ctx context.Context, file string, layer v1.Layer) error
 
 	enc = json.NewEncoder(dtodf)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(&dtod); err != nil {
-		return err
-	}
-
-	return nil
+	return enc.Encode(&dtod)
 }
 
 func (c *layerCache) readDiffToDesc(file string) (diffIDToDescriptor, error) {

--- a/pkg/build/limit_test.go
+++ b/pkg/build/limit_test.go
@@ -27,17 +27,17 @@ type sleeper struct{}
 var _ Interface = (*sleeper)(nil)
 
 // QualifyImport implements Interface
-func (r *sleeper) QualifyImport(ip string) (string, error) {
+func (*sleeper) QualifyImport(ip string) (string, error) {
 	return ip, nil
 }
 
 // IsSupportedReference implements Interface
-func (r *sleeper) IsSupportedReference(ip string) error {
+func (*sleeper) IsSupportedReference(_ string) error {
 	return nil
 }
 
 // Build implements Interface
-func (r *sleeper) Build(_ context.Context, ip string) (Result, error) {
+func (*sleeper) Build(_ context.Context, _ string) (Result, error) {
 	time.Sleep(50 * time.Millisecond)
 	return nil, nil
 }

--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -86,7 +86,7 @@ func addApply(topLevel *cobra.Command) {
 			// Issue a "kubectl apply" command reading from stdin,
 			// to which we will pipe the resolved files, and any
 			// remaining flags passed after '--'.
-			kubectlCmd := exec.CommandContext(ctx, "kubectl", append([]string{"apply", "-f", "-"}, args...)...)
+			kubectlCmd := exec.CommandContext(ctx, "kubectl", append([]string{"apply", "-f", "-"}, args...)...) //nolint:gosec
 
 			// Pass through our environment
 			kubectlCmd.Env = os.Environ()

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/google/ko/pkg/commands/options"
 	"github.com/spf13/cobra"
@@ -87,7 +86,7 @@ func addCreate(topLevel *cobra.Command) {
 			// Issue a "kubectl create" command reading from stdin,
 			// to which we will pipe the resolved files, and any
 			// remaining flags passed after '--'.
-			kubectlCmd := exec.CommandContext(ctx, "kubectl", append([]string{"create", "-f", "-"}, args...)...)
+			kubectlCmd := exec.CommandContext(ctx, "kubectl", append([]string{"create", "-f", "-"}, args...)...) //nolint:gosec
 
 			// Pass through our environment
 			kubectlCmd.Env = os.Environ()
@@ -135,15 +134,4 @@ func addCreate(topLevel *cobra.Command) {
 	options.AddBuildOptions(create, bo)
 
 	topLevel.AddCommand(create)
-}
-
-func stripPassword(flags []string) []string {
-	cp := make([]string, len(flags))
-	for _, f := range flags {
-		if strings.HasPrefix(f, "--password=") {
-			f = "--password=REDACTED"
-		}
-		cp = append(cp, f)
-	}
-	return cp
 }

--- a/pkg/publish/kind/write_test.go
+++ b/pkg/publish/kind/write_test.go
@@ -165,7 +165,7 @@ type fakeProvider struct {
 	nodes []nodes.Node
 }
 
-func (f *fakeProvider) ListInternalNodes(name string) ([]nodes.Node, error) {
+func (f *fakeProvider) ListInternalNodes(string) ([]nodes.Node, error) {
 	return f.nodes, nil
 }
 
@@ -174,7 +174,7 @@ type fakeNode struct {
 	err  error
 }
 
-func (f *fakeNode) CommandContext(ctx context.Context, cmd string, args ...string) exec.Cmd {
+func (f *fakeNode) CommandContext(_ context.Context, cmd string, args ...string) exec.Cmd {
 	command := &fakeCmd{
 		cmd: strings.Join(append([]string{cmd}, args...), " "),
 		err: f.err,
@@ -188,10 +188,10 @@ func (f *fakeNode) String() string {
 }
 
 // The following functions are not used by our code at all.
-func (f *fakeNode) Command(string, ...string) exec.Cmd        { return nil }
-func (f *fakeNode) Role() (string, error)                     { return "", nil }
-func (f *fakeNode) IP() (ipv4 string, ipv6 string, err error) { return "", "", nil }
-func (f *fakeNode) SerialLogs(writer io.Writer) error         { return nil }
+func (f *fakeNode) Command(string, ...string) exec.Cmd { return nil }
+func (f *fakeNode) Role() (string, error)              { return "", nil }
+func (f *fakeNode) IP() (string, string, error)        { return "", "", nil }
+func (f *fakeNode) SerialLogs(io.Writer) error         { return nil }
 
 type fakeCmd struct {
 	cmd   string

--- a/pkg/publish/options.go
+++ b/pkg/publish/options.go
@@ -25,7 +25,7 @@ type staticKeychain struct {
 	auth authn.Authenticator
 }
 
-func (s staticKeychain) Resolve(resource authn.Resource) (authn.Authenticator, error) {
+func (s staticKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
 	return s.auth, nil
 }
 

--- a/pkg/publish/shared_test.go
+++ b/pkg/publish/shared_test.go
@@ -31,7 +31,7 @@ type slowpublish struct {
 // slowpublish implements Interface
 var _ Interface = (*slowpublish)(nil)
 
-func (sp *slowpublish) Publish(_ context.Context, br build.Result, ref string) (name.Reference, error) {
+func (sp *slowpublish) Publish(context.Context, build.Result, string) (name.Reference, error) {
 	time.Sleep(sp.sleep)
 	return makeRef()
 }


### PR DESCRIPTION
depguard is disabled because its new default config is to only allow stdlib deps (i.e., make you explicitly list each dep in your linter, for some reason) https://github.com/golangci/golangci-lint/issues/3877

deadcode is disabled because it's unmaintained and warns when you use it.

The rest of the changes fix findings reported by newer versions of golangci-lint