### PR TITLE
fix test broken by lint fix

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -1229,8 +1229,10 @@ func (pm *platformMatcher) matches(base *v1.Platform) bool {
 					// Any other form of these osversions are not a match.
 					continue
 				}
+			} else {
+				// Partial osversion matching only allows X.Y.Z to match X.Y.Z.A.
+				continue
 			}
-			// Otherwise, partial osversion matching only allows X.Y.Z to match X.Y.Z.A.
 		}
 		return true
 	}


### PR DESCRIPTION
https://github.com/ko-build/ko/pull/1142 broke a test for Windows platform matching.