### PR TITLE
Add `--debug` build flag to include Delve debugger

### DIFF
--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -47,6 +47,7 @@ ko apply -f FILENAME [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --debug                    Include Delve debugger into image and wrap arround ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -f, --filename strings         Filename, directory, or URL to files to use to create the resource
   -h, --help                     help for apply

--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -47,7 +47,7 @@ ko apply -f FILENAME [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --debug                    Include Delve debugger into image and wrap arround ko-app. This debugger will listen to port 40000.
+      --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -f, --filename strings         Filename, directory, or URL to files to use to create the resource
   -h, --help                     help for apply

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -44,7 +44,7 @@ ko build IMPORTPATH... [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --debug                    Include Delve debugger into image and wrap arround ko-app. This debugger will listen to port 40000.
+      --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -h, --help                     help for build
       --image-label strings      Which labels (key=value) to add to the image.

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -44,6 +44,7 @@ ko build IMPORTPATH... [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --debug                    Include Delve debugger into image and wrap arround ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -h, --help                     help for build
       --image-label strings      Which labels (key=value) to add to the image.

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -47,6 +47,7 @@ ko create -f FILENAME [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --debug                    Include Delve debugger into image and wrap arround ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -f, --filename strings         Filename, directory, or URL to files to use to create the resource
   -h, --help                     help for create

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -47,7 +47,7 @@ ko create -f FILENAME [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --debug                    Include Delve debugger into image and wrap arround ko-app. This debugger will listen to port 40000.
+      --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -f, --filename strings         Filename, directory, or URL to files to use to create the resource
   -h, --help                     help for create

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -40,7 +40,7 @@ ko resolve -f FILENAME [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --debug                    Include Delve debugger into image and wrap arround ko-app. This debugger will listen to port 40000.
+      --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -f, --filename strings         Filename, directory, or URL to files to use to create the resource
   -h, --help                     help for resolve

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -40,6 +40,7 @@ ko resolve -f FILENAME [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --debug                    Include Delve debugger into image and wrap arround ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -f, --filename strings         Filename, directory, or URL to files to use to create the resource
   -h, --help                     help for resolve

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -32,6 +32,7 @@ ko run IMPORTPATH [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --debug                    Include Delve debugger into image and wrap arround ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -h, --help                     help for run
       --image-label strings      Which labels (key=value) to add to the image.

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -32,7 +32,7 @@ ko run IMPORTPATH [flags]
 ```
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --debug                    Include Delve debugger into image and wrap arround ko-app. This debugger will listen to port 40000.
+      --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.
       --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
   -h, --help                     help for run
       --image-label strings      Which labels (key=value) to add to the image.

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	gb "go/build"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -84,6 +85,7 @@ type gobuild struct {
 	platformMatcher      *platformMatcher
 	dir                  string
 	labels               map[string]string
+	debug                bool
 	semaphore            *semaphore.Weighted
 
 	cache *layerCache
@@ -107,6 +109,7 @@ type gobuildOpener struct {
 	labels               map[string]string
 	dir                  string
 	jobs                 int
+	debug                bool
 }
 
 func (gbo *gobuildOpener) Open() (Interface, error) {
@@ -133,6 +136,7 @@ func (gbo *gobuildOpener) Open() (Interface, error) {
 		buildConfigs:         gbo.buildConfigs,
 		labels:               gbo.labels,
 		dir:                  gbo.dir,
+		debug:                gbo.debug,
 		platformMatcher:      matcher,
 		cache: &layerCache{
 			buildToDiff: map[string]buildIDToDiffID{},
@@ -249,6 +253,63 @@ func getGoBinary() string {
 		return env
 	}
 	return defaultGoBin
+}
+
+func getDelve(ctx context.Context, platform v1.Platform) (string, error) {
+	env, err := buildEnv(platform, os.Environ(), nil)
+	if err != nil {
+		return "", fmt.Errorf("could not create env for Delve build: %w", err)
+	}
+
+	tmpInstallDir, err := os.MkdirTemp("", "delve")
+	if err != nil {
+		return "", fmt.Errorf("could not create tmp dir for Delve installation: %w", err)
+	}
+
+	// install delve to tmp directory
+	env = append(env, fmt.Sprintf("GOPATH=%s", tmpInstallDir))
+
+	args := []string{
+		"install",
+		"github.com/go-delve/delve/cmd/dlv@latest",
+	}
+
+	gobin := getGoBinary()
+	cmd := exec.CommandContext(ctx, gobin, args...)
+	cmd.Env = env
+
+	var output bytes.Buffer
+	cmd.Stderr = &output
+	cmd.Stdout = &output
+
+	log.Printf("Building Delve for %s", platform)
+	if err := cmd.Run(); err != nil {
+		os.RemoveAll(tmpInstallDir)
+		return "", fmt.Errorf("go build Delve: %w: %s", err, output.String())
+	}
+
+	// find the delve binary in tmpInstallDir/bin/
+	delveBinary := ""
+	err = filepath.WalkDir(filepath.Join(tmpInstallDir, "bin"), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() && strings.Contains(d.Name(), "dlv") {
+			delveBinary = path
+		}
+
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("could not search for Delve binary: %w", err)
+	}
+
+	if delveBinary == "" {
+		return "", fmt.Errorf("could not find Delve binary in %q", tmpInstallDir)
+	}
+
+	return delveBinary, nil
 }
 
 func build(ctx context.Context, ip string, dir string, platform v1.Platform, config Config) (string, error) {
@@ -905,6 +966,45 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 		},
 	})
 
+	delvePath := "" // path for delve in image
+	if g.debug {
+		// get delve locally
+		delveBinary, err := getDelve(ctx, *platform)
+		if err != nil {
+			return nil, fmt.Errorf("building Delve: %w", err)
+		}
+		defer os.RemoveAll(filepath.Dir(delveBinary))
+
+		delvePath = "/usr/bin/" + filepath.Base(delveBinary)
+
+		// add layer with delve binary
+		delveLayer, err := g.cache.get(ctx, delveBinary, func() (v1.Layer, error) {
+			return buildLayer(delvePath, delveBinary, platform, layerMediaType)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("cache.get(%q): %w", delveBinary, err)
+		}
+
+		layers = append(layers, mutate.Addendum{
+			Layer:     delveLayer,
+			MediaType: layerMediaType,
+			History: v1.History{
+				Author:    "ko",
+				Created:   g.creationTime,
+				CreatedBy: "ko build " + ref.String(),
+				Comment:   "Delve debugger, at " + delvePath,
+			},
+		})
+	}
+	delveArgs := []string{
+		"exec",
+		"--listen=:40000",
+		"--headless",
+		"--log",
+		"--accept-multiclient",
+		"--api-version=2",
+	}
+
 	// Augment the base image with our application layer.
 	withApp, err := mutate.Append(base, layers...)
 	if err != nil {
@@ -922,10 +1022,22 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 	cfg.Config.Entrypoint = []string{appPath}
 	cfg.Config.Cmd = nil
 	if platform.OS == "windows" {
-		cfg.Config.Entrypoint = []string{`C:\ko-app\` + appFileName}
+		appPath := `C:\ko-app\` + appFileName
+		if g.debug {
+			cfg.Config.Entrypoint = append([]string{"C:\\" + delvePath}, delveArgs...)
+			cfg.Config.Entrypoint = append(cfg.Config.Entrypoint, appPath)
+		} else {
+			cfg.Config.Entrypoint = []string{appPath}
+		}
+
 		updatePath(cfg, `C:\ko-app`)
 		cfg.Config.Env = append(cfg.Config.Env, `KO_DATA_PATH=C:\var\run\ko`)
 	} else {
+		if g.debug {
+			cfg.Config.Entrypoint = append([]string{delvePath}, delveArgs...)
+			cfg.Config.Entrypoint = append(cfg.Config.Entrypoint, appPath)
+		}
+
 		updatePath(cfg, appDir)
 		cfg.Config.Env = append(cfg.Config.Env, "KO_DATA_PATH="+kodataRoot)
 	}

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -177,3 +177,10 @@ func WithSBOMDir(dir string) Option {
 		return nil
 	}
 }
+
+func WithDebugger() Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.debug = true
+		return nil
+	}
+}

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -57,6 +57,7 @@ type BuildOptions struct {
 	SBOMDir              string
 	Platforms            []string
 	Labels               []string
+	Debug                bool
 	// UserAgent enables overriding the default value of the `User-Agent` HTTP
 	// request header used when retrieving the base image.
 	UserAgent string
@@ -86,6 +87,8 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
+	cmd.Flags().BoolVar(&bo.Debug, "debug", bo.Debug,
+		"Include Delve debugger into image and wrap arround ko-app. This debugger will listen to port 40000.")
 	bo.Trimpath = true
 }
 

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -88,7 +88,7 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
 	cmd.Flags().BoolVar(&bo.Debug, "debug", bo.Debug,
-		"Include Delve debugger into image and wrap arround ko-app. This debugger will listen to port 40000.")
+		"Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.")
 	bo.Trimpath = true
 }
 

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -98,6 +98,10 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 	if bo.DisableOptimizations {
 		opts = append(opts, build.WithDisabledOptimizations())
 	}
+	if bo.Debug {
+		opts = append(opts, build.WithDebugger())
+		opts = append(opts, build.WithDisabledOptimizations()) // also needed for Delve
+	}
 	switch bo.SBOM {
 	case "none":
 		opts = append(opts, build.WithDisabledSBOM())


### PR DESCRIPTION
Currently the entrypoint of the image is always set to `/ko-app/<app-name>`. This makes it hard to remote debug the app via Delve, which invokes the app e.g. via `dlv exec <path-to-app>`).

This PR adds a new build flag (`--debug`), which adds the Delve debugger to the image and sets the entrypoint to invoke delve instead of the ko-app directly.

**Hint:** 
* This idea came out of https://github.com/ko-build/ko/pull/1138#issuecomment-1713834074.
* I have only tested it on Linux. Tests on MacOS & Windows are welcome :) 
* To allow a more customized exec configuration of delve (e.g. specify port, etc.), we could allow more configuration flags, to override the default delve args. But I would see this as a follow up, to not blow up this initial PR. (IMO)

**How to test this PR:**
1. Apply a manifests with the `debug` flag. e.g. `ko apply --debug -f config/controller.yaml`
2. Start a port forwarding for Delve: `kubectl port-forward deploy/my-controller 40000:40000`
3. Connect from your IDE to the remote debugger. E.g. use the following VSCode launch config: 
      ````
      {
          "version": "0.2.0",
          "configurations": [{
                  "name": "Attach to remote",
                  "type": "go",
                  "request": "attach",
                  "mode": "remote",
                  "port": 40000,
                  "host": "0.0.0.0",
                  "showLog": true,
                  "cwd": "${workspaceFolder}"
              }
          ]
      }
      ````