### PR TITLE
Don't AppendDescriptor until we've written config

### DIFF
--- a/pkg/commands/cache.go
+++ b/pkg/commands/cache.go
@@ -165,10 +165,6 @@ func (i *imageCache) get(ctx context.Context, ref name.Reference, missFunc baseF
 			return result, err
 		}
 
-		if err := i.p.AppendDescriptor(*desc); err != nil {
-			return result, err
-		}
-
 		if _, ok := result.(v1.ImageIndex); ok {
 			result = &lazyIndex{
 				ref:      ref,
@@ -201,6 +197,10 @@ func (i *imageCache) get(ctx context.Context, ref name.Reference, missFunc baseF
 				miss:     missFunc,
 				cache:    i,
 			}
+		}
+
+		if err := i.p.AppendDescriptor(*desc); err != nil {
+			return result, err
 		}
 	}
 


### PR DESCRIPTION
I have a suspicion that this is causing a race where we modify the cache's index.json file before we actually write out the image's config file, so if we call RawConfigFile before we finish caching it, we'll just fail to find that file.