### PR TITLE
Fix "AM" Time Typo

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -2,7 +2,7 @@
 
 ## Meetings
 
-We have a bi-weekly community meeting on [Wednesdays at 1:00 AM US Eastern time, 10:00 AM US Western time](https://dateful.com/eventlink/2763257725). The main goal of these meetings is that we want to hear from you! We want to know what you're using `ko` for, what you'd like to see in `ko`, how we can make `ko` better for you. With any remaining time we can go through open issues and PRs.
+We have a bi-weekly community meeting on [Wednesdays at 1:00 PM US Eastern time, 10:00 AM US Western time](https://dateful.com/eventlink/2763257725). The main goal of these meetings is that we want to hear from you! We want to know what you're using `ko` for, what you'd like to see in `ko`, how we can make `ko` better for you. With any remaining time we can go through open issues and PRs.
 
 We have a [meeting agenda](https://ko.build/agenda) you can use to propose topics for discussion/ideas. You can also just show up and we'll figure out what to talk about.
 


### PR DESCRIPTION
Community page stated biweekly meeting was at `Wednesdays at 1:00 AM US Eastern time, 10:00 AM US Western time`. The 'AM' for US Eastern is likely intended to be a 'PM'.