### PR TITLE
(feat) Adding styling to code blocks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,3 +57,12 @@ plugins:
         'slack.md':     'https://kubernetes.slack.com/archives/C01T7DTP65S'
         'agenda.md':    'https://docs.google.com/document/d/1eQ67Qxwf1tkTv0yU_dw9bIRnlwJZz-5GXCRVOhqbgvU/edit'
         'meet.md':      'meet.google.com/xvn-dzzk-wur'
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences


### PR DESCRIPTION
I noticed that the code blocks lack styling, which makes them just a little bit harder to read.

This PR updates the `mkdocs.yaml` file to add in the required styling as per [the documentation](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/)

As far as I know, there should not be any additional imports required for the mkdocs GHA

## Before

<img width="786" alt="image" src="https://github.com/ko-build/ko/assets/41597815/a074fb51-7bb7-48ac-89d9-b26a57adaf6e">


## After

<img width="773" alt="image" src="https://github.com/ko-build/ko/assets/41597815/3d9f947c-37c6-4a62-bd31-bafdcc00fed1">

---

_note: I have got a previous CLA with Google_