### PR TITLE
Correct cluster name in error message when no nodes are found

### DIFF
--- a/pkg/publish/kind/write.go
+++ b/pkg/publish/kind/write.go
@@ -114,7 +114,7 @@ func getNodes() ([]nodes.Node, error) {
 		return nil, err
 	}
 	if len(nodeList) == 0 {
-		return nil, fmt.Errorf("no nodes found for cluster %q", cluster.DefaultName)
+		return nil, fmt.Errorf("no nodes found for cluster %q", clusterName)
 	}
 
 	return nodeList, nil


### PR DESCRIPTION
This fixes the error message when no nodes exist to print the correct cluster name.