### PR TITLE
feat: allow commas in --image-label but not multiple labels

### DIFF
--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -45,27 +45,27 @@ ko apply -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for apply
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                      Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths         Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations     Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings          Filename, directory, or URL to files to use to create the resource
+  -h, --help                      help for apply
+      --image-label stringArray   Which labels (key=value) to add to the image.
+      --image-refs string         Path to file where a list of the published image references will be written.
+      --insecure-registry         Whether to skip TLS verification on the registry
+  -j, --jobs int                  The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                     Load into images to local docker daemon.
+      --oci-layout-path string    Path to save the OCI image layout of the built images
+      --platform strings          Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths     Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                      Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                 Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string               The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string           Path to file where the SBOM will be written.
+  -l, --selector string           Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                  Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings              Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string            File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -42,24 +42,24 @@ ko build IMPORTPATH... [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -h, --help                     help for build
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                      Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths         Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations     Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                      help for build
+      --image-label stringArray   Which labels (key=value) to add to the image.
+      --image-refs string         Path to file where a list of the published image references will be written.
+      --insecure-registry         Whether to skip TLS verification on the registry
+  -j, --jobs int                  The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                     Load into images to local docker daemon.
+      --oci-layout-path string    Path to save the OCI image layout of the built images
+      --platform strings          Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths     Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                      Push images to KO_DOCKER_REPO (default true)
+      --sbom string               The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string           Path to file where the SBOM will be written.
+      --tag-only                  Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings              Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string            File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -45,27 +45,27 @@ ko create -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for create
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                      Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths         Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations     Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings          Filename, directory, or URL to files to use to create the resource
+  -h, --help                      help for create
+      --image-label stringArray   Which labels (key=value) to add to the image.
+      --image-refs string         Path to file where a list of the published image references will be written.
+      --insecure-registry         Whether to skip TLS verification on the registry
+  -j, --jobs int                  The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                     Load into images to local docker daemon.
+      --oci-layout-path string    Path to save the OCI image layout of the built images
+      --platform strings          Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths     Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                      Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                 Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string               The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string           Path to file where the SBOM will be written.
+  -l, --selector string           Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                  Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings              Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string            File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -38,27 +38,27 @@ ko resolve -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for resolve
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                      Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths         Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations     Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings          Filename, directory, or URL to files to use to create the resource
+  -h, --help                      help for resolve
+      --image-label stringArray   Which labels (key=value) to add to the image.
+      --image-refs string         Path to file where a list of the published image references will be written.
+      --insecure-registry         Whether to skip TLS verification on the registry
+  -j, --jobs int                  The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                     Load into images to local docker daemon.
+      --oci-layout-path string    Path to save the OCI image layout of the built images
+      --platform strings          Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths     Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                      Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                 Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string               The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string           Path to file where the SBOM will be written.
+  -l, --selector string           Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                  Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings              Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string            File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -30,24 +30,24 @@ ko run IMPORTPATH [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -h, --help                     help for run
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                      Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths         Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations     Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                      help for run
+      --image-label stringArray   Which labels (key=value) to add to the image.
+      --image-refs string         Path to file where a list of the published image references will be written.
+      --insecure-registry         Whether to skip TLS verification on the registry
+  -j, --jobs int                  The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                     Load into images to local docker daemon.
+      --oci-layout-path string    Path to save the OCI image layout of the built images
+      --platform strings          Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths     Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                      Push images to KO_DOCKER_REPO (default true)
+      --sbom string               The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string           Path to file where the SBOM will be written.
+      --tag-only                  Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings              Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string            File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -82,7 +82,7 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Path to file where the SBOM will be written.")
 	cmd.Flags().StringSliceVar(&bo.Platforms, "platform", []string{},
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
-	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
+	cmd.Flags().StringArrayVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
 	bo.Trimpath = true
 }


### PR DESCRIPTION
Resolves #622

# Context

Currently, `--image-label` expects a list of `key=value` labels separated by commas. This means it is impossible to have labels whose value contain commas.

This is problematic for descriptions (as shown in #622) but also labels that mandate commas like `moby.buildkit.frontend.caps` (e.g. `moby.buildkit.frontend.caps=moby.buildkit.frontend.inputs,moby.buildkit.frontend.contexts`).

Those commas also can't be escaped to make `pflag` keep the values as one label.

# Fix

TL;DR: this change might be considered a breaking change due to CLI flags not doing the exact same thing as before.

The issue can be solved easily by replacing `StringSliceVar` with `StringArrayVar`. However, it does mean `--image-label foo=bar,baz=qux` will stay as `["foo=bar,baz=qux"]` instead of the current `["foo=bar", "baz=qux"]` which might be unexpected for current users of `--image-label`.

From the name (`--image-label`) I did expect it to take only a single value instead of a comma-separated one but the description (`Which labels (key=value) to add to the image.`) seems to say the opposite. 

# Alternative

Trying to support both options in one flag (`--image-label`) seems difficult and quite error-prone so might it be possible to consider adding a new option (e.g. `--image-add-label`, `--image-single-label`, etc) which can support label with commas?
