### PR TITLE
annotation support

### DIFF
--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -45,27 +45,28 @@ ko apply -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for apply
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                       Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths          Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations      Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings           Filename, directory, or URL to files to use to create the resource
+  -h, --help                       help for apply
+      --image-annotation strings   Which annotations (key=value) to add to the image.
+      --image-label strings        Which labels (key=value) to add to the image.
+      --image-refs string          Path to file where a list of the published image references will be written.
+      --insecure-registry          Whether to skip TLS verification on the registry
+  -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                      Load into images to local docker daemon.
+      --oci-layout-path string     Path to save the OCI image layout of the built images
+      --platform strings           Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths      Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                       Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                  Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string                The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string            Path to file where the SBOM will be written.
+  -l, --selector string            Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string             File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -42,24 +42,25 @@ ko build IMPORTPATH... [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -h, --help                     help for build
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                       Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths          Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations      Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                       help for build
+      --image-annotation strings   Which annotations (key=value) to add to the image.
+      --image-label strings        Which labels (key=value) to add to the image.
+      --image-refs string          Path to file where a list of the published image references will be written.
+      --insecure-registry          Whether to skip TLS verification on the registry
+  -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                      Load into images to local docker daemon.
+      --oci-layout-path string     Path to save the OCI image layout of the built images
+      --platform strings           Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths      Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                       Push images to KO_DOCKER_REPO (default true)
+      --sbom string                The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string            Path to file where the SBOM will be written.
+      --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string             File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -45,27 +45,28 @@ ko create -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for create
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                       Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths          Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations      Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings           Filename, directory, or URL to files to use to create the resource
+  -h, --help                       help for create
+      --image-annotation strings   Which annotations (key=value) to add to the image.
+      --image-label strings        Which labels (key=value) to add to the image.
+      --image-refs string          Path to file where a list of the published image references will be written.
+      --insecure-registry          Whether to skip TLS verification on the registry
+  -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                      Load into images to local docker daemon.
+      --oci-layout-path string     Path to save the OCI image layout of the built images
+      --platform strings           Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths      Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                       Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                  Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string                The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string            Path to file where the SBOM will be written.
+  -l, --selector string            Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string             File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -38,27 +38,28 @@ ko resolve -f FILENAME [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -f, --filename strings         Filename, directory, or URL to files to use to create the resource
-  -h, --help                     help for resolve
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-  -R, --recursive                Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-  -l, --selector string          Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                       Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths          Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations      Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -f, --filename strings           Filename, directory, or URL to files to use to create the resource
+  -h, --help                       help for resolve
+      --image-annotation strings   Which annotations (key=value) to add to the image.
+      --image-label strings        Which labels (key=value) to add to the image.
+      --image-refs string          Path to file where a list of the published image references will be written.
+      --insecure-registry          Whether to skip TLS verification on the registry
+  -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                      Load into images to local docker daemon.
+      --oci-layout-path string     Path to save the OCI image layout of the built images
+      --platform strings           Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths      Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                       Push images to KO_DOCKER_REPO (default true)
+  -R, --recursive                  Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
+      --sbom string                The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string            Path to file where the SBOM will be written.
+  -l, --selector string            Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string             File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -30,24 +30,25 @@ ko run IMPORTPATH [flags]
 ### Options
 
 ```
-      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
-  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
-      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
-  -h, --help                     help for run
-      --image-label strings      Which labels (key=value) to add to the image.
-      --image-refs string        Path to file where a list of the published image references will be written.
-      --insecure-registry        Whether to skip TLS verification on the registry
-  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
-  -L, --local                    Load into images to local docker daemon.
-      --oci-layout-path string   Path to save the OCI image layout of the built images
-      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
-  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
-      --push                     Push images to KO_DOCKER_REPO (default true)
-      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
-      --sbom-dir string          Path to file where the SBOM will be written.
-      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
-  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string           File to save images tarballs
+      --bare                       Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths          Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --disable-optimizations      Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                       help for run
+      --image-annotation strings   Which annotations (key=value) to add to the image.
+      --image-label strings        Which labels (key=value) to add to the image.
+      --image-refs string          Path to file where a list of the published image references will be written.
+      --insecure-registry          Whether to skip TLS verification on the registry
+  -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                      Load into images to local docker daemon.
+      --oci-layout-path string     Path to save the OCI image layout of the built images
+      --platform strings           Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths      Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                       Push images to KO_DOCKER_REPO (default true)
+      --sbom string                The SBOM media type to use (none will disable SBOM synthesis and upload, also supports: spdx, cyclonedx, go.version-m). (default "spdx")
+      --sbom-dir string            Path to file where the SBOM will be written.
+      --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string             File to save images tarballs
 ```
 
 ### Options inherited from parent commands

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -717,6 +717,7 @@ func TestGoBuild(t *testing.T) {
 		withSBOMber(fauxSBOM),
 		WithLabel("foo", "bar"),
 		WithLabel("hello", "world"),
+		WithAnnotations("bar", "baz"),
 		WithPlatforms("all"),
 	)
 	if err != nil {
@@ -769,6 +770,23 @@ func TestGoBuild(t *testing.T) {
 		got := cfg.Config.Labels
 		if d := cmp.Diff(got, want); d != "" {
 			t.Fatalf("Labels diff (-got,+want): %s", d)
+		}
+	})
+
+	t.Run("check annotations", func(t *testing.T) {
+		manifest, err := img.Manifest()
+		if err != nil {
+			t.Fatalf("Manifest() = %v", err)
+		}
+
+		want := map[string]string{
+			"bar": "baz",
+		}
+		for k, v1 := range want {
+			v2 := manifest.Annotations[k]
+			if v1 != v2 {
+				t.Fatalf("Annotation %s: wanted %q, got %q", k, v1, v2)
+			}
 		}
 	})
 }

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -117,6 +117,17 @@ func WithLabel(k, v string) Option {
 	}
 }
 
+// WithAnnotations is a functional option for adding annotations to built images.
+func WithAnnotations(k, v string) Option {
+	return func(gbo *gobuildOpener) error {
+		if gbo.annotations == nil {
+			gbo.annotations = map[string]string{}
+		}
+		gbo.annotations[k] = v
+		return nil
+	}
+}
+
 // withBuilder is a functional option for overriding the way go binaries
 // are built.
 func withBuilder(b builder) Option {

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -55,6 +55,7 @@ type BuildOptions struct {
 	SBOMDir              string
 	Platforms            []string
 	Labels               []string
+	Annotations          []string
 	// UserAgent enables overriding the default value of the `User-Agent` HTTP
 	// request header used when retrieving the base image.
 	UserAgent string
@@ -84,6 +85,8 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*")
 	cmd.Flags().StringSliceVar(&bo.Labels, "image-label", []string{},
 		"Which labels (key=value) to add to the image.")
+	cmd.Flags().StringSliceVar(&bo.Annotations, "image-annotation", []string{},
+		"Which annotations (key=value) to add to the image.")
 	bo.Trimpath = true
 }
 

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -116,6 +116,13 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		}
 		opts = append(opts, build.WithLabel(parts[0], parts[1]))
 	}
+	for _, lf := range bo.Annotations {
+		parts := strings.SplitN(lf, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid annotation flag: %s", lf)
+		}
+		opts = append(opts, build.WithAnnotations(parts[0], parts[1]))
+	}
 
 	if bo.BuildConfigs != nil {
 		opts = append(opts, build.WithConfig(bo.BuildConfigs))


### PR DESCRIPTION
same use case as https://github.com/ko-build/ko/issues/1090, pushing to ghcr registry. this PR adds ability to set annotations for both single/multi-arch builds, so they are nicely labelled on ghcr.io:

```
ko build --tags=v0.0.1 \
    --sbom=none --platform linux/amd64,linux/arm64 \
    --image-annotation org.opencontainers.image.source='https://github.com/foo/bar' \
    --image-annotation org.opencontainers.image.description='something about the package' \
    --push=true --bare \
    .
```

references:
- https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
- https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images