### PR TITLE
BUGFIX: passing a --oci-layout-path value with uppercase letters caused ko to fail

### DIFF
--- a/pkg/publish/layout.go
+++ b/pkg/publish/layout.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -80,7 +81,7 @@ func (l *LayoutPublisher) Publish(_ context.Context, br build.Result, s string) 
 		return nil, err
 	}
 
-	dig, err := name.NewDigest(fmt.Sprintf("%s@%s", l.p, h))
+	dig, err := name.NewDigest(fmt.Sprintf("%s@%s", strings.ToLower(string(l.p)), h))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This can be reproduces very easily:
```bash
$ ko build . --oci-layout-path=AAAAA --push=false
2024/01/19 13:21:23 Using base golang:latest@sha256:5f5d61dcb58900bc57b230431b6367c900f9982b583adcabf9fa93fd0aa5544a for github.com/google/ko
2024/01/19 13:21:24 Using build config ko for github.com/google/ko
2024/01/19 13:21:24 Building github.com/google/ko for linux/amd64
2024/01/19 13:21:25 Saving ko://github.com/google/ko
2024/01/19 13:21:25 Saved ko://github.com/google/ko
Error: failed to publish images: error publishing ko://github.com/google/ko: repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: AAAAA
exit status 1
```
On OSX especially this causes issues when you provide an absolute path.

This PR implements a very basic fix, printing the lowercase version of the path instead of the original path.