### PR TITLE
drop go1.20 and start testing with go1.22 and ci updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - '1.20'
           - '1.21'
+          - '1.22'
 
     name: Build ${{ matrix.go-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/modules-integration-test.yaml
+++ b/.github/workflows/modules-integration-test.yaml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - '1.20'
           - '1.21'
+          - '1.22'
 
     runs-on: 'ubuntu-latest'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       # This installs the current latest release.
       - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
         with:
-          version: v0.14.1
+          version: v0.15.2
 
       - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -32,5 +32,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
         with:
-          version: v1.54
+          version: v1.56
           args: --timeout=5m

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20240323062759-1fd604ae58de
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589
-	github.com/docker/docker v25.0.3+incompatible
+	github.com/docker/docker v25.0.5+incompatible
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936
 	github.com/go-training/helloworld v0.0.0-20200225145412-ba5f4379d78b
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/docker/cli v24.0.7+incompatible h1:wa/nIwYFW7BVTGa7SWPVyyXU9lgORqUb1x
 github.com/docker/cli v24.0.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v25.0.3+incompatible h1:D5fy/lYmY7bvZa0XTZ5/UJPljor41F+vdyJG5luQLfQ=
-github.com/docker/docker v25.0.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v25.0.5+incompatible h1:UmQydMduGkrD5nQde1mecF/YnSbTOaPeFIeP5C4W+DE=
+github.com/docker/docker v25.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.1 h1:j/eKUktUltBtMzKqmfLB0PAgqYyMHOp5vfsD1807oKo=
 github.com/docker/docker-credential-helpers v0.8.1/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -20,14 +20,6 @@ echo "Copying ko to temp gopath."
 mkdir -p "$GOPATH/src/github.com/google/ko"
 cp -r "$ROOT_DIR/"* "$GOPATH/src/github.com/google/ko/"
 
-echo "Downloading github.com/go-training/helloworld"
-GO111MODULE=off go get -d github.com/go-training/helloworld
-
-pushd "$GOPATH/src/github.com/google/ko" || exit 1
-
-echo "Replacing hello world in vendor with TEST."
-sed -i 's/Hello World/TEST/g' ./vendor/github.com/go-training/helloworld/main.go
-
 echo "Building ko"
 
 RESULT="$(GO111MODULE="on" GOFLAGS="-mod=vendor" go build .)"
@@ -36,15 +28,7 @@ echo "Beginning scenarios."
 
 FILTER="[^ ]local[^ ]*"
 
-echo "1. GOPATH mode should always create an image that outputs 'Hello World'"
-RESULT="$(GO111MODULE=off ./ko build --local github.com/go-training/helloworld  | grep "$FILTER" | xargs -I% docker run %)"
-if [[ "$RESULT" != *"Hello World"** ]]; then
-  echo "Test FAILED. Saw $RESULT" && exit 1
-else
-  echo "Test PASSED"
-fi
-
-echo "2. Go module auto mode should create an image that outputs 'Hello World' when run outside the module."
+echo "1. Go module auto mode should create an image that outputs 'Hello World' when run outside the module."
 
 pushd .. || exit 1
 RESULT="$(GO111MODULE=auto GOFLAGS="-mod=vendor" ./ko/ko build --local github.com/go-training/helloworld  | grep "$FILTER" | xargs -I% docker run %)"
@@ -56,7 +40,7 @@ fi
 
 popd || exit 1
 
-echo "3. Auto inside the module with vendoring should output TEST"
+echo "2. Auto inside the module with vendoring should output TEST"
 
 RESULT="$(GO111MODULE=auto GOFLAGS="-mod=vendor" ./ko build --local github.com/go-training/helloworld  | grep "$FILTER" | xargs -I% docker run %)"
 if [[ "$RESULT" != *"TEST"* ]]; then
@@ -65,7 +49,7 @@ else
   echo "Test PASSED"
 fi
 
-echo "4. Auto inside the module without vendoring should output TEST"
+echo "3. Auto inside the module without vendoring should output TEST"
 RESULT="$(GO111MODULE=auto GOFLAGS="" ./ko build --local github.com/go-training/helloworld  | grep "$FILTER" | xargs -I% docker run %)"
 if [[ "$RESULT" != *"TEST"* ]]; then
   echo "Test FAILED. Saw $RESULT" && exit 1
@@ -73,7 +57,7 @@ else
   echo "Test PASSED"
 fi
 
-echo "5. On inside the module with vendor should output TEST."
+echo "4. On inside the module with vendor should output TEST."
 RESULT="$(GO111MODULE=on GOFLAGS="-mod=vendor" ./ko build --local github.com/go-training/helloworld  | grep "$FILTER" | xargs -I% docker run %)"
 if [[ "$RESULT" != *"TEST"* ]]; then
   echo "Test FAILED. Saw $RESULT" && exit 1
@@ -81,7 +65,7 @@ else
   echo "Test PASSED"
 fi
 
-echo "6. On inside the module without vendor should output TEST"
+echo "5. On inside the module without vendor should output TEST"
 RESULT="$(GO111MODULE=on GOFLAGS="" ./ko build --local github.com/go-training/helloworld  | grep "$FILTER" | xargs -I% docker run %)"
 if [[ "$RESULT" != *"TEST"* ]]; then
   echo "Test FAILED. Saw $RESULT" && exit 1
@@ -89,12 +73,12 @@ else
   echo "Test PASSED"
 fi
 
-echo "7. On outside the module should fail."
+echo "6. On outside the module should fail."
 pushd .. || exit 1
 GO111MODULE=on ./ko/ko build --local github.com/go-training/helloworld && exit 1
 popd || exit 1
 
-echo "8. On outside with build config specifying the test module builds."
+echo "7. On outside with build config specifying the test module builds."
 pushd test/build-configs || exit 1
 for app in foo bar ; do
   # test both local and fully qualified import paths

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -20,6 +20,8 @@ echo "Copying ko to temp gopath."
 mkdir -p "$GOPATH/src/github.com/google/ko"
 cp -r "$ROOT_DIR/"* "$GOPATH/src/github.com/google/ko/"
 
+pushd "$GOPATH/src/github.com/google/ko" || exit 1
+
 echo "Building ko"
 
 RESULT="$(GO111MODULE="on" GOFLAGS="-mod=vendor" go build .)"
@@ -31,8 +33,8 @@ FILTER="[^ ]local[^ ]*"
 echo "1. Go module auto mode should create an image that outputs 'Hello World' when run outside the module."
 
 pushd .. || exit 1
-RESULT="$(GO111MODULE=auto GOFLAGS="-mod=vendor" ./ko/ko build --local github.com/go-training/helloworld  | grep "$FILTER" | xargs -I% docker run %)"
-if [[ "$RESULT" != *"Hello World"* ]]; then
+RESULT="$(GO111MODULE=auto GOFLAGS="-mod=vendor" ./ko/ko build --local "$GOPATH/src/github.com/google/ko/test"  | grep "$FILTER" | xargs -I% docker run %)"
+if [[ "$RESULT" != *"Hello there"* ]]; then
   echo "Test FAILED. Saw $RESULT" && exit 1
 else
   echo "Test PASSED"
@@ -40,34 +42,34 @@ fi
 
 popd || exit 1
 
-echo "2. Auto inside the module with vendoring should output TEST"
+echo "2. Auto inside the module with vendoring should output Hello there"
 
-RESULT="$(GO111MODULE=auto GOFLAGS="-mod=vendor" ./ko build --local github.com/go-training/helloworld  | grep "$FILTER" | xargs -I% docker run %)"
-if [[ "$RESULT" != *"TEST"* ]]; then
+RESULT="$(GO111MODULE=auto GOFLAGS="-mod=vendor" ./ko build --local "$GOPATH/src/github.com/google/ko/test"  | grep "$FILTER" | xargs -I% docker run %)"
+if [[ "$RESULT" != *"Hello there"* ]]; then
   echo "Test FAILED. Saw $RESULT" && exit 1
 else
   echo "Test PASSED"
 fi
 
-echo "3. Auto inside the module without vendoring should output TEST"
-RESULT="$(GO111MODULE=auto GOFLAGS="" ./ko build --local github.com/go-training/helloworld  | grep "$FILTER" | xargs -I% docker run %)"
-if [[ "$RESULT" != *"TEST"* ]]; then
+echo "3. Auto inside the module without vendoring should output Hello there"
+RESULT="$(GO111MODULE=auto GOFLAGS="" ./ko build --local "$GOPATH/src/github.com/google/ko/test"  | grep "$FILTER" | xargs -I% docker run %)"
+if [[ "$RESULT" != *"Hello there"* ]]; then
   echo "Test FAILED. Saw $RESULT" && exit 1
 else
   echo "Test PASSED"
 fi
 
-echo "4. On inside the module with vendor should output TEST."
-RESULT="$(GO111MODULE=on GOFLAGS="-mod=vendor" ./ko build --local github.com/go-training/helloworld  | grep "$FILTER" | xargs -I% docker run %)"
-if [[ "$RESULT" != *"TEST"* ]]; then
+echo "4. On inside the module with vendor should output Hello there."
+RESULT="$(GO111MODULE=on GOFLAGS="-mod=vendor" ./ko build --local "$GOPATH/src/github.com/google/ko/test"  | grep "$FILTER" | xargs -I% docker run %)"
+if [[ "$RESULT" != *"Hello there"* ]]; then
   echo "Test FAILED. Saw $RESULT" && exit 1
 else
   echo "Test PASSED"
 fi
 
-echo "5. On inside the module without vendor should output TEST"
-RESULT="$(GO111MODULE=on GOFLAGS="" ./ko build --local github.com/go-training/helloworld  | grep "$FILTER" | xargs -I% docker run %)"
-if [[ "$RESULT" != *"TEST"* ]]; then
+echo "5. On inside the module without vendor should output Hello there"
+RESULT="$(GO111MODULE=on GOFLAGS="" ./ko build --local "$GOPATH/src/github.com/google/ko/test"  | grep "$FILTER" | xargs -I% docker run %)"
+if [[ "$RESULT" != *"Hello there"* ]]; then
   echo "Test FAILED. Saw $RESULT" && exit 1
 else
   echo "Test PASSED"
@@ -75,7 +77,7 @@ fi
 
 echo "6. On outside the module should fail."
 pushd .. || exit 1
-GO111MODULE=on ./ko/ko build --local github.com/go-training/helloworld && exit 1
+GO111MODULE=on ./ko/ko build --local "$GOPATH/src/github.com/google/ko/test" && exit 1
 popd || exit 1
 
 echo "7. On outside with build config specifying the test module builds."

--- a/pkg/build/recorder_test.go
+++ b/pkg/build/recorder_test.go
@@ -101,7 +101,7 @@ func TestBuildRecording(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			inner := &fake{
-				b: func(ip string) (Result, error) {
+				b: func(_ string) (Result, error) {
 					return nil, nil
 				},
 			}

--- a/pkg/commands/resolve.go
+++ b/pkg/commands/resolve.go
@@ -54,7 +54,7 @@ func addResolve(topLevel *cobra.Command) {
   # This always preserves import paths.
   ko resolve --local -f config/`,
 		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := options.Validate(po, bo); err != nil {
 				return fmt.Errorf("validating options: %w", err)
 			}

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -32,7 +32,7 @@ func New() *cobra.Command {
 		Short:             "Rapidly iterate with Go, Containers, and Kubernetes.",
 		SilenceUsage:      true, // Don't show usage on errors
 		DisableAutoGenTag: true,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(_ *cobra.Command, _ []string) {
 			if verbose {
 				logs.Warn.SetOutput(os.Stderr)
 				logs.Debug.SetOutput(os.Stderr)
@@ -41,7 +41,7 @@ func New() *cobra.Command {
 
 			maxprocs.Set(maxprocs.Logger(logs.Debug.Printf))
 		},
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			cmd.Help()
 		},
 	}

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -29,7 +29,7 @@ func addVersion(topLevel *cobra.Command) {
 	topLevel.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: `Print ko version.`,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			v := version()
 			if v == "" {
 				fmt.Println("could not determine build information")

--- a/pkg/publish/recorder.go
+++ b/pkg/publish/recorder.go
@@ -55,7 +55,7 @@ func (r *recorder) Publish(ctx context.Context, br build.Result, ref string) (na
 	references := make([]string, 0, 20 /* just try to avoid resizing*/)
 	switch t := br.(type) {
 	case oci.SignedImageIndex:
-		if err := walk.SignedEntity(ctx, t, func(ctx context.Context, se oci.SignedEntity) error {
+		if err := walk.SignedEntity(ctx, t, func(_ context.Context, se oci.SignedEntity) error {
 			// Both of the SignedEntity types implement Digest()
 			h, err := se.(interface{ Digest() (v1.Hash, error) }).Digest()
 			if err != nil {

--- a/pkg/publish/recorder_test.go
+++ b/pkg/publish/recorder_test.go
@@ -42,7 +42,7 @@ func (sp *cbPublish) Close() error {
 
 func TestRecorder(t *testing.T) {
 	repo := name.MustParseReference("docker.io/ubuntu:latest")
-	inner := &cbPublish{cb: func(c context.Context, b build.Result, s string) (name.Reference, error) {
+	inner := &cbPublish{cb: func(_ context.Context, b build.Result, _ string) (name.Reference, error) {
 		h, err := b.Digest()
 		if err != nil {
 			return nil, err

--- a/test/main.go
+++ b/test/main.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	f    = flag.String("f", "kenobi", "File in kodata to print")
-	wait = flag.Bool("wait", true, "Whether to wait for SIGTERM")
+	wait = flag.Bool("wait", false, "Whether to wait for SIGTERM")
 )
 
 // This is defined so we can test build-time variable setting using ldflags.
@@ -66,7 +66,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error reading %q: %v", file, err)
 	}
-	log.Print(string(bytes))
+	fmt.Println(string(bytes))
 
 	// Cause the pod to "hang" to allow us to check for a readiness state.
 	if *wait {

--- a/test/test.yaml
+++ b/test/test.yaml
@@ -19,4 +19,6 @@ spec:
   containers:
   - name: obiwan
     image: ko://github.com/google/ko/test
+    args:
+      - --wait=true
   restartPolicy: Never

--- a/vendor/github.com/docker/docker/api/swagger.yaml
+++ b/vendor/github.com/docker/docker/api/swagger.yaml
@@ -391,7 +391,11 @@ definitions:
           ReadOnlyNonRecursive:
             description: |
                Make the mount non-recursively read-only, but still leave the mount recursive
-               (unless NonRecursive is set to true in conjunction).
+               (unless NonRecursive is set to `true` in conjunction).
+
+               Addded in v1.44, before that version all read-only mounts were
+               non-recursive by default. To match the previous behaviour this
+               will default to `true` for clients on versions prior to v1.44.
             type: "boolean"
             default: false
           ReadOnlyForceRecursive:
@@ -1743,8 +1747,12 @@ definitions:
         description: |
           Date and time at which the image was created, formatted in
           [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+
+          This information is only available if present in the image,
+          and omitted otherwise.
         type: "string"
-        x-nullable: false
+        format: "dateTime"
+        x-nullable: true
         example: "2022-02-04T21:20:12.497794809Z"
       Container:
         description: |

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -72,7 +72,10 @@ type ImageInspect struct {
 
 	// Created is the date and time at which the image was created, formatted in
 	// RFC 3339 nano-seconds (time.RFC3339Nano).
-	Created string
+	//
+	// This information is only available if present in the image,
+	// and omitted otherwise.
+	Created string `json:",omitempty"`
 
 	// Container is the ID of the container that was used to create the image.
 	//

--- a/vendor/github.com/docker/docker/client/container_create.go
+++ b/vendor/github.com/docker/docker/client/container_create.go
@@ -28,7 +28,9 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	//
 	// Normally, version-negotiation (if enabled) would not happen until
 	// the API request is made.
-	cli.checkVersion(ctx)
+	if err := cli.checkVersion(ctx); err != nil {
+		return response, err
+	}
 
 	if err := cli.NewVersionError(ctx, "1.25", "stop timeout"); config != nil && config.StopTimeout != nil && err != nil {
 		return response, err

--- a/vendor/github.com/docker/docker/client/container_exec.go
+++ b/vendor/github.com/docker/docker/client/container_exec.go
@@ -18,7 +18,9 @@ func (cli *Client) ContainerExecCreate(ctx context.Context, container string, co
 	//
 	// Normally, version-negotiation (if enabled) would not happen until
 	// the API request is made.
-	cli.checkVersion(ctx)
+	if err := cli.checkVersion(ctx); err != nil {
+		return response, err
+	}
 
 	if err := cli.NewVersionError(ctx, "1.25", "env"); len(config.Env) != 0 && err != nil {
 		return response, err

--- a/vendor/github.com/docker/docker/client/container_restart.go
+++ b/vendor/github.com/docker/docker/client/container_restart.go
@@ -23,7 +23,9 @@ func (cli *Client) ContainerRestart(ctx context.Context, containerID string, opt
 		//
 		// Normally, version-negotiation (if enabled) would not happen until
 		// the API request is made.
-		cli.checkVersion(ctx)
+		if err := cli.checkVersion(ctx); err != nil {
+			return err
+		}
 		if versions.GreaterThanOrEqualTo(cli.version, "1.42") {
 			query.Set("signal", options.Signal)
 		}

--- a/vendor/github.com/docker/docker/client/container_stop.go
+++ b/vendor/github.com/docker/docker/client/container_stop.go
@@ -27,7 +27,9 @@ func (cli *Client) ContainerStop(ctx context.Context, containerID string, option
 		//
 		// Normally, version-negotiation (if enabled) would not happen until
 		// the API request is made.
-		cli.checkVersion(ctx)
+		if err := cli.checkVersion(ctx); err != nil {
+			return err
+		}
 		if versions.GreaterThanOrEqualTo(cli.version, "1.42") {
 			query.Set("signal", options.Signal)
 		}

--- a/vendor/github.com/docker/docker/client/container_wait.go
+++ b/vendor/github.com/docker/docker/client/container_wait.go
@@ -30,18 +30,21 @@ const containerWaitErrorMsgLimit = 2 * 1024 /* Max: 2KiB */
 // synchronize ContainerWait with other calls, such as specifying a
 // "next-exit" condition before issuing a ContainerStart request.
 func (cli *Client) ContainerWait(ctx context.Context, containerID string, condition container.WaitCondition) (<-chan container.WaitResponse, <-chan error) {
+	resultC := make(chan container.WaitResponse)
+	errC := make(chan error, 1)
+
 	// Make sure we negotiated (if the client is configured to do so),
 	// as code below contains API-version specific handling of options.
 	//
 	// Normally, version-negotiation (if enabled) would not happen until
 	// the API request is made.
-	cli.checkVersion(ctx)
+	if err := cli.checkVersion(ctx); err != nil {
+		errC <- err
+		return resultC, errC
+	}
 	if versions.LessThan(cli.ClientVersion(), "1.30") {
 		return cli.legacyContainerWait(ctx, containerID)
 	}
-
-	resultC := make(chan container.WaitResponse)
-	errC := make(chan error, 1)
 
 	query := url.Values{}
 	if condition != "" {

--- a/vendor/github.com/docker/docker/client/errors.go
+++ b/vendor/github.com/docker/docker/client/errors.go
@@ -11,15 +11,16 @@ import (
 
 // errConnectionFailed implements an error returned when connection failed.
 type errConnectionFailed struct {
-	host string
+	error
 }
 
 // Error returns a string representation of an errConnectionFailed
-func (err errConnectionFailed) Error() string {
-	if err.host == "" {
-		return "Cannot connect to the Docker daemon. Is the docker daemon running on this host?"
-	}
-	return fmt.Sprintf("Cannot connect to the Docker daemon at %s. Is the docker daemon running?", err.host)
+func (e errConnectionFailed) Error() string {
+	return e.error.Error()
+}
+
+func (e errConnectionFailed) Unwrap() error {
+	return e.error
 }
 
 // IsErrConnectionFailed returns true if the error is caused by connection failed.
@@ -29,7 +30,13 @@ func IsErrConnectionFailed(err error) bool {
 
 // ErrorConnectionFailed returns an error with host in the error message when connection to docker daemon failed.
 func ErrorConnectionFailed(host string) error {
-	return errConnectionFailed{host: host}
+	var err error
+	if host == "" {
+		err = fmt.Errorf("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
+	} else {
+		err = fmt.Errorf("Cannot connect to the Docker daemon at %s. Is the docker daemon running?", host)
+	}
+	return errConnectionFailed{error: err}
 }
 
 // IsErrNotFound returns true if the error is a NotFound error, which is returned
@@ -60,7 +67,9 @@ func (cli *Client) NewVersionError(ctx context.Context, APIrequired, feature str
 	//
 	// Normally, version-negotiation (if enabled) would not happen until
 	// the API request is made.
-	cli.checkVersion(ctx)
+	if err := cli.checkVersion(ctx); err != nil {
+		return err
+	}
 	if cli.version != "" && versions.LessThan(cli.version, APIrequired) {
 		return fmt.Errorf("%q requires API version %s, but the Docker daemon API version is %s", feature, APIrequired, cli.version)
 	}

--- a/vendor/github.com/docker/docker/client/image_list.go
+++ b/vendor/github.com/docker/docker/client/image_list.go
@@ -13,14 +13,17 @@ import (
 
 // ImageList returns a list of images in the docker host.
 func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions) ([]image.Summary, error) {
+	var images []image.Summary
+
 	// Make sure we negotiated (if the client is configured to do so),
 	// as code below contains API-version specific handling of options.
 	//
 	// Normally, version-negotiation (if enabled) would not happen until
 	// the API request is made.
-	cli.checkVersion(ctx)
+	if err := cli.checkVersion(ctx); err != nil {
+		return images, err
+	}
 
-	var images []image.Summary
 	query := url.Values{}
 
 	optionFilters := options.Filters

--- a/vendor/github.com/docker/docker/client/network_create.go
+++ b/vendor/github.com/docker/docker/client/network_create.go
@@ -10,12 +10,16 @@ import (
 
 // NetworkCreate creates a new network in the docker host.
 func (cli *Client) NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error) {
+	var response types.NetworkCreateResponse
+
 	// Make sure we negotiated (if the client is configured to do so),
 	// as code below contains API-version specific handling of options.
 	//
 	// Normally, version-negotiation (if enabled) would not happen until
 	// the API request is made.
-	cli.checkVersion(ctx)
+	if err := cli.checkVersion(ctx); err != nil {
+		return response, err
+	}
 
 	networkCreateRequest := types.NetworkCreateRequest{
 		NetworkCreate: options,
@@ -25,7 +29,6 @@ func (cli *Client) NetworkCreate(ctx context.Context, name string, options types
 		networkCreateRequest.CheckDuplicate = true //nolint:staticcheck // ignore SA1019: CheckDuplicate is deprecated since API v1.44.
 	}
 
-	var response types.NetworkCreateResponse
 	serverResp, err := cli.post(ctx, "/networks/create", nil, networkCreateRequest, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {

--- a/vendor/github.com/docker/docker/client/ping.go
+++ b/vendor/github.com/docker/docker/client/ping.go
@@ -14,7 +14,10 @@ import (
 // Ping pings the server and returns the value of the "Docker-Experimental",
 // "Builder-Version", "OS-Type" & "API-Version" headers. It attempts to use
 // a HEAD request on the endpoint, but falls back to GET if HEAD is not supported
-// by the daemon.
+// by the daemon. It ignores internal server errors returned by the API, which
+// may be returned if the daemon is in an unhealthy state, but returns errors
+// for other non-success status codes, failing to connect to the API, or failing
+// to parse the API response.
 func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 	var ping types.Ping
 

--- a/vendor/github.com/docker/docker/client/service_create.go
+++ b/vendor/github.com/docker/docker/client/service_create.go
@@ -25,7 +25,9 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 	//
 	// Normally, version-negotiation (if enabled) would not happen until
 	// the API request is made.
-	cli.checkVersion(ctx)
+	if err := cli.checkVersion(ctx); err != nil {
+		return response, err
+	}
 
 	// Make sure containerSpec is not nil when no runtime is set or the runtime is set to container
 	if service.TaskTemplate.ContainerSpec == nil && (service.TaskTemplate.Runtime == "" || service.TaskTemplate.Runtime == swarm.RuntimeContainer) {

--- a/vendor/github.com/docker/docker/client/service_update.go
+++ b/vendor/github.com/docker/docker/client/service_update.go
@@ -16,18 +16,18 @@ import (
 // It should be the value as set *before* the update. You can find this value in the Meta field
 // of swarm.Service, which can be found using ServiceInspectWithRaw.
 func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error) {
+	response := swarm.ServiceUpdateResponse{}
+
 	// Make sure we negotiated (if the client is configured to do so),
 	// as code below contains API-version specific handling of options.
 	//
 	// Normally, version-negotiation (if enabled) would not happen until
 	// the API request is made.
-	cli.checkVersion(ctx)
+	if err := cli.checkVersion(ctx); err != nil {
+		return response, err
+	}
 
-	var (
-		query    = url.Values{}
-		response = swarm.ServiceUpdateResponse{}
-	)
-
+	query := url.Values{}
 	if options.RegistryAuthFrom != "" {
 		query.Set("registryAuthFrom", options.RegistryAuthFrom)
 	}

--- a/vendor/github.com/docker/docker/client/volume_remove.go
+++ b/vendor/github.com/docker/docker/client/volume_remove.go
@@ -16,7 +16,9 @@ func (cli *Client) VolumeRemove(ctx context.Context, volumeID string, force bool
 		//
 		// Normally, version-negotiation (if enabled) would not happen until
 		// the API request is made.
-		cli.checkVersion(ctx)
+		if err := cli.checkVersion(ctx); err != nil {
+			return err
+		}
 		if versions.GreaterThanOrEqualTo(cli.version, "1.25") {
 			query.Set("force", "1")
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,7 +190,7 @@ github.com/docker/cli/cli/config/types
 # github.com/docker/distribution v2.8.3+incompatible
 ## explicit
 github.com/docker/distribution/registry/client/auth/challenge
-# github.com/docker/docker v25.0.3+incompatible
+# github.com/docker/docker v25.0.5+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
- drop go1.20 and start testing with go1.22
- bump ko to v0.15.2
- bump golangci-lint to v1.56.x