### PR TITLE
feat: add image user option

### DIFF
--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -54,6 +54,7 @@ ko apply -f FILENAME [flags]
       --image-annotation strings   Which annotations (key=value[,key=value]) to add to the OCI manifest.
       --image-label strings        Which labels (key=value[,key=value]) to add to the image.
       --image-refs string          Path to file where a list of the published image references will be written.
+      --image-user string          The default user the image should be run as.
       --insecure-registry          Whether to skip TLS verification on the registry
   -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
   -L, --local                      Load into images to local docker daemon.

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -50,6 +50,7 @@ ko build IMPORTPATH... [flags]
       --image-annotation strings   Which annotations (key=value[,key=value]) to add to the OCI manifest.
       --image-label strings        Which labels (key=value[,key=value]) to add to the image.
       --image-refs string          Path to file where a list of the published image references will be written.
+      --image-user string          The default user the image should be run as.
       --insecure-registry          Whether to skip TLS verification on the registry
   -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
   -L, --local                      Load into images to local docker daemon.

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -54,6 +54,7 @@ ko create -f FILENAME [flags]
       --image-annotation strings   Which annotations (key=value[,key=value]) to add to the OCI manifest.
       --image-label strings        Which labels (key=value[,key=value]) to add to the image.
       --image-refs string          Path to file where a list of the published image references will be written.
+      --image-user string          The default user the image should be run as.
       --insecure-registry          Whether to skip TLS verification on the registry
   -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
   -L, --local                      Load into images to local docker daemon.

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -47,6 +47,7 @@ ko resolve -f FILENAME [flags]
       --image-annotation strings   Which annotations (key=value[,key=value]) to add to the OCI manifest.
       --image-label strings        Which labels (key=value[,key=value]) to add to the image.
       --image-refs string          Path to file where a list of the published image references will be written.
+      --image-user string          The default user the image should be run as.
       --insecure-registry          Whether to skip TLS verification on the registry
   -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
   -L, --local                      Load into images to local docker daemon.

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -38,6 +38,7 @@ ko run IMPORTPATH [flags]
       --image-annotation strings   Which annotations (key=value[,key=value]) to add to the OCI manifest.
       --image-label strings        Which labels (key=value[,key=value]) to add to the image.
       --image-refs string          Path to file where a list of the published image references will be written.
+      --image-user string          The default user the image should be run as.
       --insecure-registry          Whether to skip TLS verification on the registry
   -j, --jobs int                   The maximum number of concurrent builds (default GOMAXPROCS)
   -L, --local                      Load into images to local docker daemon.

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -103,6 +103,7 @@ type gobuild struct {
 	dir                  string
 	labels               map[string]string
 	annotations          map[string]string
+	user                 string
 	debug                bool
 	semaphore            *semaphore.Weighted
 
@@ -129,6 +130,7 @@ type gobuildOpener struct {
 	platforms            []string
 	labels               map[string]string
 	annotations          map[string]string
+	user                 string
 	dir                  string
 	jobs                 int
 	debug                bool
@@ -151,6 +153,7 @@ func (gbo *gobuildOpener) Open() (Interface, error) {
 	return &gobuild{
 		ctx:                  gbo.ctx,
 		getBase:              gbo.getBase,
+		user:                 gbo.user,
 		creationTime:         gbo.creationTime,
 		kodataCreationTime:   gbo.kodataCreationTime,
 		build:                gbo.build,
@@ -1170,6 +1173,10 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 	}
 	for k, v := range g.labels {
 		cfg.Config.Labels[k] = v
+	}
+
+	if g.user != "" {
+		cfg.Config.User = g.user
 	}
 
 	empty := v1.Time{}

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -846,6 +846,7 @@ func TestGoBuild(t *testing.T) {
 		WithLabel("hello", "world"),
 		WithAnnotation("fizz", "buzz"),
 		WithAnnotation("goodbye", "world"),
+		WithUser("1234:1234"),
 		WithPlatforms("all"),
 	)
 	if err != nil {
@@ -919,6 +920,19 @@ func TestGoBuild(t *testing.T) {
 		got := man.Annotations
 		if d := cmp.Diff(got, want); d != "" {
 			t.Fatalf("Annotations diff (-got,+want): %s", d)
+		}
+	})
+
+	t.Run("check user", func(t *testing.T) {
+		cfg, err := img.ConfigFile()
+		if err != nil {
+			t.Fatalf("ConfigFile() = %v", err)
+		}
+
+		want := "1234:1234"
+		got := cfg.Config.User
+		if got != want {
+			t.Fatalf("User: %s != %s", want, got)
 		}
 	})
 }

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -153,6 +153,14 @@ func WithAnnotation(k, v string) Option {
 	}
 }
 
+// WithUser is a functional option for overriding the user in the image config.
+func WithUser(user string) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.user = user
+		return nil
+	}
+}
+
 // withBuilder is a functional option for overriding the way go binaries
 // are built.
 func withBuilder(b builder) Option {

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -66,6 +66,7 @@ type BuildOptions struct {
 	Platforms            []string
 	Labels               []string
 	Annotations          []string
+	User                 string
 	Debug                bool
 	// UserAgent enables overriding the default value of the `User-Agent` HTTP
 	// request header used when retrieving the base image.
@@ -98,6 +99,8 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Which labels (key=value[,key=value]) to add to the image.")
 	cmd.Flags().StringSliceVar(&bo.Annotations, "image-annotation", []string{},
 		"Which annotations (key=value[,key=value]) to add to the OCI manifest.")
+	cmd.Flags().StringVar(&bo.User, "image-user", "",
+		"The default user the image should be run as.")
 	cmd.Flags().BoolVar(&bo.Debug, "debug", bo.Debug,
 		"Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.")
 	bo.Trimpath = true

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -127,6 +127,10 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		opts = append(opts, build.WithAnnotation(k, v))
 	}
 
+	if bo.User != "" {
+		opts = append(opts, build.WithUser(bo.User))
+	}
+
 	if bo.BuildConfigs != nil {
 		opts = append(opts, build.WithConfig(bo.BuildConfigs))
 	}


### PR DESCRIPTION
Hello! :wave:

When using a base image that does not set a user (e.g. `busybox`), it is desirable to set a non-root user for the built image. At the moment, this requires building a custom image built with another tool to set this value. Since it is a simple config field, it seems reasonable to have an option for it