### PR TITLE
feat: Add global env

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,31 @@ You can also use the `KO_DEFAULTPLATFORMS` environment variable to set the defau
 KO_DEFAULTPLATFORMS=linux/arm64,linux/amd64
 ```
 
+### Setting build environment variables
+
+By default, `ko` builds use the ambient environment from the system (i.e. `os.Environ()`).
+These values can be overridden globally or per-build (or both).
+
+```yaml
+env:
+- FOO=foo
+builds:
+- id: foo
+  dir: .
+  main: ./foobar/foo
+  env:
+  - FOO=bar # Overrides the global value.
+- id: bar
+  dir: ./bar
+  main: .
+```
+
+For a given build, the environment variables are merged in the following order:
+
+- System `os.Environ` (lowest precedence)
+- Global `env`
+- Build `env` (highest precedence)
+
 ### Environment Variables (advanced)
 
 For ease of use, backward compatibility and advanced use cases, `ko` supports the following environment variables to

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -85,6 +85,15 @@ func WithConfig(buildConfigs map[string]Config) Option {
 	}
 }
 
+// WithEnv is a functional option for providing a global set of environment
+// variables across all builds.
+func WithEnv(env []string) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.env = env
+		return nil
+	}
+}
+
 // WithPlatforms is a functional option for building certain platforms for
 // multi-platform base images. To build everything from the base, use "all",
 // otherwise use a list of platform specs, i.e.:

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -47,6 +47,9 @@ type BuildOptions struct {
 	// DefaultPlatforms defines the default platforms when Platforms is not explicitly defined
 	DefaultPlatforms []string
 
+	// Env allows setting environment variables globally and applying them to each build.
+	Env []string
+
 	// WorkingDirectory allows for setting the working directory for invocations of the `go` tool.
 	// Empty string means the current working directory.
 	WorkingDirectory string
@@ -136,6 +139,11 @@ func (bo *BuildOptions) LoadConfig() error {
 	dp := v.GetStringSlice("defaultPlatforms")
 	if len(dp) > 0 {
 		bo.DefaultPlatforms = dp
+	}
+
+	env := v.GetStringSlice("env")
+	if len(env) > 0 {
+		bo.Env = env
 	}
 
 	if bo.BaseImage == "" {

--- a/pkg/commands/options/build_test.go
+++ b/pkg/commands/options/build_test.go
@@ -67,6 +67,21 @@ func TestDefaultPlatformsAll(t *testing.T) {
 	}
 }
 
+func TestEnv(t *testing.T) {
+	bo := &BuildOptions{
+		WorkingDirectory: "testdata/config",
+	}
+	err := bo.LoadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantEnv := []string{"FOO=bar"} // matches value in ./testdata/config/.ko.yaml
+	if !reflect.DeepEqual(bo.Env, wantEnv) {
+		t.Fatalf("wanted Env %s, got %s", wantEnv, bo.Env)
+	}
+}
+
 func TestBuildConfigWithWorkingDirectoryAndDirAndMain(t *testing.T) {
 	bo := &BuildOptions{
 		WorkingDirectory: "testdata/paths",

--- a/pkg/commands/options/testdata/config/.ko.yaml
+++ b/pkg/commands/options/testdata/config/.ko.yaml
@@ -1,2 +1,3 @@
 defaultBaseImage: alpine
 defaultPlatforms: all
+env: FOO=bar

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -86,6 +86,7 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 
 	opts := []build.Option{
 		build.WithBaseImages(getBaseImage(bo)),
+		build.WithEnv(bo.Env),
 		build.WithPlatforms(bo.Platforms...),
 		build.WithJobs(bo.ConcurrentBuilds),
 	}


### PR DESCRIPTION
Supports configuring global `env` variables that will be applied to all builds.

Modifies the `builder` function to accept a `buildContext` structure. This will simplify similar modifications in the future.

Fixes #1305