### PR TITLE
Refactor global values to be defaults

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,18 +125,18 @@ KO_DEFAULTPLATFORMS=linux/arm64,linux/amd64
 ### Setting build environment variables
 
 By default, `ko` builds use the ambient environment from the system (i.e. `os.Environ()`).
-These values can be overridden globally or per-build (or both).
+These values can be overridden for your build.
 
 ```yaml
-env:
+defaultEnv:
 - FOO=foo
 builds:
 - id: foo
   dir: .
   main: ./foobar/foo
   env:
-  - FOO=bar # Overrides the global value.
-- id: bar
+  - FOO=bar
+- id: bar     # Will use defaultEnv.
   dir: ./bar
   main: .
 ```
@@ -144,33 +144,32 @@ builds:
 For a given build, the environment variables are merged in the following order:
 
 - System `os.Environ` (lowest precedence)
-- Global `env`
-- Build `env` (highest precedence)
+- Build variables: `build.env` if specified, otherwise `defaultEnv` (highest precedence)
 
 ### Setting build flags and ldflags
 
 You can specify both `flags` and `ldflags` globally as well as per-build.
 
 ```yaml
-flags:
+defaultFlags:
 - -v
-ldflags:
+defaultLdflags:
 - -s
 builds:
 - id: foo
   dir: .
   main: ./foobar/foo
   flags:
-  - -trimpath # Build will use: -v -trimpath
+  - -trimpath
   ldflags:
-  - -w # Build will use: -s -w
-- id: bar
+  - -w
+- id: bar     # Will use defaultFlags and defaultLdflags.
   dir: ./bar
   main: .
 ```
 
-The values for each `build` will be appended to the global values when creating each build.
-Both global and per-build values may use [template parameters](#templating-support).
+The values for a `build` will be used if specified, otherwise their respective defaults will be used.
+Both default and per-build values may use [template parameters](#templating-support).
 
 ### Environment Variables (advanced)
 

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -44,6 +44,7 @@ else
 fi
 
 echo "2. Test knative 'KO_FLAGS' variable is ignored."
+# https://github.com/ko-build/ko/issues/1317
 RESULT="$(KO_FLAGS="--platform=badvalue" ./ko build --local --platform="linux/$GOARCH" "$GOPATH/src/github.com/google/ko/test" | grep "$FILTER" | xargs -I% docker run %)"
 if [[ "$RESULT" != *"Hello there"* ]]; then
   echo "Test FAILED. Saw $RESULT" && exit 1

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -43,7 +43,15 @@ else
   echo "Test PASSED"
 fi
 
-echo "2. Linux capabilities."
+echo "2. Test knative 'KO_FLAGS' variable is ignored."
+RESULT="$(KO_FLAGS="--platform=badvalue" ./ko build --local --platform="linux/$GOARCH" "$GOPATH/src/github.com/google/ko/test" | grep "$FILTER" | xargs -I% docker run %)"
+if [[ "$RESULT" != *"Hello there"* ]]; then
+  echo "Test FAILED. Saw $RESULT" && exit 1
+else
+  echo "Test PASSED"
+fi
+
+echo "3. Linux capabilities."
 pushd test/build-configs || exit 1
 # run as non-root user with net_bind_service cap granted
 docker_run_opts="--user 1 --cap-add=net_bind_service"

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -85,27 +85,27 @@ func WithConfig(buildConfigs map[string]Config) Option {
 	}
 }
 
-// WithEnv is a functional option for providing a global set of environment
+// WithDefaultEnv is a functional option for providing a default set of environment
 // variables across all builds.
-func WithEnv(env []string) Option {
+func WithDefaultEnv(env []string) Option {
 	return func(gbo *gobuildOpener) error {
-		gbo.env = env
+		gbo.defaultEnv = env
 		return nil
 	}
 }
 
-// WithFlags is a functional option for providing a global set of flags across all builds.
-func WithFlags(flags []string) Option {
+// WithDefaultFlags is a functional option for providing a default set of flags across all builds.
+func WithDefaultFlags(flags []string) Option {
 	return func(gbo *gobuildOpener) error {
-		gbo.flags = flags
+		gbo.defaultFlags = flags
 		return nil
 	}
 }
 
-// WithLdflags is a functional option for providing a global set of ldflags across all builds.
-func WithLdflags(ldflags []string) Option {
+// WithDefaultLdflags is a functional option for providing a default set of ldflags across all builds.
+func WithDefaultLdflags(ldflags []string) Option {
 	return func(gbo *gobuildOpener) error {
-		gbo.ldflags = ldflags
+		gbo.defaultLdflags = ldflags
 		return nil
 	}
 }

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -22,12 +22,11 @@ import (
 	"reflect"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/ko/pkg/build"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/tools/go/packages"
-
-	"github.com/google/ko/pkg/build"
 )
 
 const (
@@ -47,14 +46,14 @@ type BuildOptions struct {
 	// DefaultPlatforms defines the default platforms when Platforms is not explicitly defined
 	DefaultPlatforms []string
 
-	// Env allows setting environment variables globally and applying them to each build.
-	Env []string
+	// DefaultEnv defines the default environment when per-build value is not explicitly defined.
+	DefaultEnv []string
 
-	// Flags allows setting flags globally and applying them to each build.
-	Flags []string
+	// DefaultFlags defines the default flags when per-build value is not explicitly defined.
+	DefaultFlags []string
 
-	// Ldflags allows setting ldflags globally and applying them to each build.
-	Ldflags []string
+	// DefaultLdflags defines the default ldflags when per-build value is not explicitly defined.
+	DefaultLdflags []string
 
 	// WorkingDirectory allows for setting the working directory for invocations of the `go` tool.
 	// Empty string means the current working directory.
@@ -146,16 +145,16 @@ func (bo *BuildOptions) LoadConfig() error {
 		bo.DefaultPlatforms = dp
 	}
 
-	if env := v.GetStringSlice("env"); len(env) > 0 {
-		bo.Env = env
+	if env := v.GetStringSlice("defaultEnv"); len(env) > 0 {
+		bo.DefaultEnv = env
 	}
 
-	if flags := v.GetStringSlice("flags"); len(flags) > 0 {
-		bo.Flags = flags
+	if flags := v.GetStringSlice("defaultFlags"); len(flags) > 0 {
+		bo.DefaultFlags = flags
 	}
 
-	if ldflags := v.GetStringSlice("ldflags"); len(ldflags) > 0 {
-		bo.Ldflags = ldflags
+	if ldflags := v.GetStringSlice("defaultLdflags"); len(ldflags) > 0 {
+		bo.DefaultLdflags = ldflags
 	}
 
 	if bo.BaseImage == "" {

--- a/pkg/commands/options/build_test.go
+++ b/pkg/commands/options/build_test.go
@@ -68,31 +68,31 @@ func TestDefaultPlatformsAll(t *testing.T) {
 	}
 }
 
-func TestEnv(t *testing.T) {
+func TestDefaultEnv(t *testing.T) {
 	bo := &BuildOptions{
 		WorkingDirectory: "testdata/config",
 	}
 	err := bo.LoadConfig()
 	require.NoError(t, err)
-	require.Equal(t, []string{"FOO=bar"}, bo.Env)
+	require.Equal(t, []string{"FOO=bar"}, bo.DefaultEnv)
 }
 
-func TestFlags(t *testing.T) {
+func TestDefaultFlags(t *testing.T) {
 	bo := &BuildOptions{
 		WorkingDirectory: "testdata/config",
 	}
 	err := bo.LoadConfig()
 	require.NoError(t, err)
-	require.Equal(t, []string{"-tags", "netgo"}, bo.Flags)
+	require.Equal(t, []string{"-tags", "netgo"}, bo.DefaultFlags)
 }
 
-func TestLDFlags(t *testing.T) {
+func TestDefaultLdFlags(t *testing.T) {
 	bo := &BuildOptions{
 		WorkingDirectory: "testdata/config",
 	}
 	err := bo.LoadConfig()
 	require.NoError(t, err)
-	require.Equal(t, []string{"-s -w"}, bo.Ldflags)
+	require.Equal(t, []string{"-s -w"}, bo.DefaultLdflags)
 }
 
 func TestBuildConfigWithWorkingDirectoryAndDirAndMain(t *testing.T) {

--- a/pkg/commands/options/testdata/config/.ko.yaml
+++ b/pkg/commands/options/testdata/config/.ko.yaml
@@ -1,8 +1,8 @@
 defaultBaseImage: alpine
 defaultPlatforms: all
-env: FOO=bar
-flags:
+defaultEnv: FOO=bar
+defaultFlags:
   - -tags
   - netgo
-ldflags:
+defaultLdflags:
   - -s -w

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -86,9 +86,9 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 
 	opts := []build.Option{
 		build.WithBaseImages(getBaseImage(bo)),
-		build.WithEnv(bo.Env),
-		build.WithFlags(bo.Flags),
-		build.WithLdflags(bo.Ldflags),
+		build.WithDefaultEnv(bo.DefaultEnv),
+		build.WithDefaultFlags(bo.DefaultFlags),
+		build.WithDefaultLdflags(bo.DefaultLdflags),
 		build.WithPlatforms(bo.Platforms...),
 		build.WithJobs(bo.ConcurrentBuilds),
 	}


### PR DESCRIPTION
There was recent work to add global values for `env`, `flags`, and `ldflags`. The global values would be merged with per-build values to generate the value used for the builds.

There are a couple issues with this:

- It's inconsistent with the existing code, which only has `default` values declared globally (there is no merging today).
- The name of the `flag` variable, caused a conflict with knative's `KO_FLAGS` environment variable (see https://github.com/ko-build/ko/issues/1317)

This PR does the following:

- Refactors the logic to use `defaultEnv`, `defaultFlags`, and `defaultLdflags`. This resolves both issues described above.
- Updates documentation

Fixes https://github.com/ko-build/ko/issues/1317