### PR TITLE
Fix a typo in terraform.md

### DIFF
--- a/docs/advanced/terraform.md
+++ b/docs/advanced/terraform.md
@@ -28,7 +28,7 @@ resource "ko_build" "app" {
 
 // Report the build image's digest.
 output "image" {
-  value = ko_build.app.image
+  value = ko_build.app.image_ref
 }
 ```
 


### PR DESCRIPTION
The field name of `image` does not exist per https://registry.terraform.io/providers/ko-build/ko/latest/docs/resources/build#read-only.

Found this problem while trying to use it, and confirmed it working with this fix.