### PR TITLE
Update recorder to lazy create file.

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -266,11 +266,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 	}
 
 	if po.ImageRefsFile != "" {
-		f, err := os.OpenFile(po.ImageRefsFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
-		if err != nil {
-			return nil, err
-		}
-		innerPublisher, err = publish.NewRecorder(innerPublisher, f)
+		innerPublisher, err = publish.NewRecorder(innerPublisher, po.ImageRefsFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/publish/recorder.go
+++ b/pkg/publish/recorder.go
@@ -28,7 +28,7 @@ import (
 )
 
 // recorder wraps a publisher implementation in a layer that recordes the published
-// references to an io.Writer.
+// references to a file.
 type recorder struct {
 	inner    Interface
 	fileName string
@@ -39,7 +39,7 @@ type recorder struct {
 var _ Interface = (*recorder)(nil)
 
 // NewRecorder wraps the provided publish.Interface in an implementation that
-// records publish results to an io.Writer.
+// records publish results to a file.
 func NewRecorder(inner Interface, name string) (Interface, error) {
 	return &recorder{
 		inner:    inner,

--- a/pkg/publish/recorder_test.go
+++ b/pkg/publish/recorder_test.go
@@ -15,8 +15,9 @@
 package publish
 
 import (
-	"bytes"
 	"context"
+	"os"
+	"path"
 	"strings"
 	"testing"
 
@@ -50,9 +51,10 @@ func TestRecorder(t *testing.T) {
 		return repo.Context().Digest(h.String()), nil
 	}}
 
-	buf := bytes.NewBuffer(nil)
+	dir := t.TempDir()
+	file := path.Join(dir, "testfile")
 
-	recorder, err := NewRecorder(inner, buf)
+	recorder, err := NewRecorder(inner, file)
 	if err != nil {
 		t.Fatalf("NewRecorder() = %v", err)
 	}
@@ -82,7 +84,11 @@ func TestRecorder(t *testing.T) {
 		t.Errorf("recorder.Close() = %v", err)
 	}
 
-	refs := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	buf, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("os.ReadFile() = %v", err)
+	}
+	refs := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	if want, got := len(refs), 5; got != want {
 		t.Errorf("len(refs) = %d, wanted %d", got, want)


### PR DESCRIPTION
Currently the resolver command creates the image-refs file on initialization. This causes git to be dirty during builds. This change moves the file creation to be in the recorder itself and on the first time the Publish() method is called. This happens after the build so git is clean. This will mean that any errors on file creation will be reported after the build rather than before.

Fixes #1378