### PR TITLE
Change OCI Layout publisher to lazy create layout after build.

### DIFF
--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -213,10 +213,7 @@ func makePublisher(po *options.PublishOptions) (publish.Interface, error) {
 
 		publishers := []publish.Interface{}
 		if po.OCILayoutPath != "" {
-			lp, err := publish.NewLayout(po.OCILayoutPath)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create LayoutPublisher for %q: %w", po.OCILayoutPath, err)
-			}
+			lp := publish.NewLayout(po.OCILayoutPath)
 			publishers = append(publishers, lp)
 		}
 		if po.TarballFile != "" {

--- a/pkg/publish/layout_test.go
+++ b/pkg/publish/layout_test.go
@@ -36,10 +36,7 @@ func TestLayout(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	lp, err := NewLayout(tmp)
-	if err != nil {
-		t.Errorf("NewLayout() = %v", err)
-	}
+	lp := NewLayout(tmp)
 	if d, err := lp.Publish(context.Background(), img, importpath); err != nil {
 		t.Errorf("Publish() = %v", err)
 	} else if !strings.HasPrefix(d.String(), tmp) {

--- a/pkg/publish/multi_test.go
+++ b/pkg/publish/multi_test.go
@@ -48,10 +48,7 @@ func TestMulti(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	lp, err := publish.NewLayout(tmp)
-	if err != nil {
-		t.Errorf("NewLayout() = %v", err)
-	}
+	lp := publish.NewLayout(tmp)
 
 	p := publish.MultiPublisher(lp, tp)
 	if _, err := p.Publish(context.Background(), img, importpath); err != nil {


### PR DESCRIPTION
When using ko with OCI Layout, Git status will always be dirty because the layout is created before this build. This changes the layout to be created after the build so that git will be clean. The means that any error creating the layout won't be seen until after the build.