### PR TITLE
Allow configuring app directory/path binaries are placed into

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -183,6 +183,18 @@ influence the build process.
 | `KO_CONFIG_PATH` | `./.ko.yaml`                               | Path to `ko` configuration file (optional)                                                                                                                                                                                       |
 | `KOCACHE`        | (not set)                                  | This tells `ko` to store a local mapping between the `go build` inputs to the image layer that they produce, so `go build` can be skipped entirely if the layer is already present in the image registry (optional).             |
 
+## Overwriting which directory binaries are placed in
+
+By default `ko` places executable binaries of your application into `/ko-app`.
+
+As it is sometimes desirable to place an executable into a specific folder inside
+the container, or into a default executable path like `/bin` or `/usr/local/bin`,
+this directory can be overwritten.
+
+This custom path can be defined either
+- via the `--app-dir` command line flag
+- or a `defaultAppDirectory` entry in the `.ko.yaml` file.
+
 ## Naming Images
 
 `ko` provides a few different strategies for naming the image it pushes, to

--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -45,6 +45,7 @@ ko apply -f FILENAME [flags]
 ### Options
 
 ```
+      --app-dir string           Directory the application binaries should be placed inside the container instead of default /ko-app.
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
       --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -42,6 +42,7 @@ ko build IMPORTPATH... [flags]
 ### Options
 
 ```
+      --app-dir string           Directory the application binaries should be placed inside the container instead of default /ko-app.
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
       --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -45,6 +45,7 @@ ko create -f FILENAME [flags]
 ### Options
 
 ```
+      --app-dir string           Directory the application binaries should be placed inside the container instead of default /ko-app.
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
       --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -38,6 +38,7 @@ ko resolve -f FILENAME [flags]
 ### Options
 
 ```
+      --app-dir string           Directory the application binaries should be placed inside the container instead of default /ko-app.
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
       --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -30,6 +30,7 @@ ko run IMPORTPATH [flags]
 ### Options
 
 ```
+      --app-dir string           Directory the application binaries should be placed inside the container instead of default /ko-app.
       --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
   -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
       --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -56,6 +56,7 @@ import (
 
 const (
 	defaultAppFilename = "ko-app"
+	defaultAppDir      = "/ko-app"
 
 	defaultGoBin = "go"         // defaults to first go binary found in PATH
 	goBinPathEnv = "KO_GO_PATH" // env lookup for optional relative or full go binary path
@@ -587,12 +588,12 @@ func tarBinary(name, binary string, platform *v1.Platform, opts *layerOptions) (
 	// For Windows, the layer must contain a Hives/ directory, and the root
 	// of the actual filesystem goes in a Files/ directory.
 	// For Linux, the binary goes into /ko-app/
-	dirs := []string{"ko-app"}
+	dirs := []string{defaultAppDir}
 	if platform.OS == "windows" {
 		dirs = []string{
 			"Hives",
 			"Files",
-			"Files/ko-app",
+			path.Join("Files", defaultAppDir),
 		}
 		name = "Files" + name
 	}
@@ -1043,7 +1044,7 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 		},
 	})
 
-	appDir := "/ko-app"
+	appDir := defaultAppDir
 	appFileName := appFilename(ref.Path())
 	appPath := path.Join(appDir, appFileName)
 
@@ -1089,7 +1090,7 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 		}
 		defer os.RemoveAll(filepath.Dir(delveBinary))
 
-		delvePath = path.Join("/ko-app", filepath.Base(delveBinary))
+		delvePath = path.Join(defaultAppDir, filepath.Base(delveBinary))
 
 		// add layer with delve binary
 		delveLayer, err := g.cache.get(ctx, delveBinary, func() (v1.Layer, error) {
@@ -1136,7 +1137,7 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 	cfg.Config.Entrypoint = []string{appPath}
 	cfg.Config.Cmd = nil
 	if platform.OS == "windows" {
-		appPath := `C:\ko-app\` + appFileName
+		appPath := strings.Replace(path.Join("C:", defaultAppDir, appFileName), "/", `\`, -1)
 		if g.debug {
 			cfg.Config.Entrypoint = append([]string{"C:\\" + delvePath}, delveArgs...)
 			cfg.Config.Entrypoint = append(cfg.Config.Entrypoint, appPath)
@@ -1144,7 +1145,8 @@ func (g *gobuild) buildOne(ctx context.Context, refStr string, base v1.Image, pl
 			cfg.Config.Entrypoint = []string{appPath}
 		}
 
-		updatePath(cfg, `C:\ko-app`)
+		addDirPath := strings.Replace(path.Join("C:", defaultAppDir), "/", `\`, -1)
+		updatePath(cfg, addDirPath)
 		cfg.Config.Env = append(cfg.Config.Env, `KO_DATA_PATH=C:\var\run\ko`)
 	} else {
 		if g.useDebugging(*platform) {

--- a/pkg/build/gobuild_test.go
+++ b/pkg/build/gobuild_test.go
@@ -640,7 +640,13 @@ func TestGoBuildNoKoData(t *testing.T) {
 	})
 }
 
-func validateImage(t *testing.T, img oci.SignedImage, baseLayers int64, creationTime v1.Time, checkAnnotations bool, expectSBOM bool) {
+type validationOptions struct {
+	checkAnnotations   bool
+	expectSBOM         bool
+	entryPointBasePath string
+}
+
+func validateImage(t *testing.T, img oci.SignedImage, baseLayers int64, creationTime v1.Time, opts validationOptions) {
 	t.Helper()
 
 	ls, err := img.Layers()
@@ -722,7 +728,11 @@ func validateImage(t *testing.T, img oci.SignedImage, baseLayers int64, creation
 			t.Errorf("len(entrypoint) = %v, want %v", got, want)
 		}
 
-		if got, want := entrypoint[0], "/ko-app/test"; got != want {
+		want := "/ko-app/test"
+		if opts.entryPointBasePath != "" {
+			want = path.Join(opts.entryPointBasePath, "test")
+		}
+		if got := entrypoint[0]; got != want {
 			t.Errorf("entrypoint = %v, want %v", got, want)
 		}
 	})
@@ -756,7 +766,9 @@ func validateImage(t *testing.T, img oci.SignedImage, baseLayers int64, creation
 				pathValue := strings.TrimPrefix(envVar, "PATH=")
 				pathEntries := strings.Split(pathValue, ":")
 				for _, pathEntry := range pathEntries {
-					if pathEntry == "/ko-app" {
+					if opts.entryPointBasePath != "" && pathEntry == opts.entryPointBasePath {
+						found = true
+					} else if pathEntry == "/ko-app" {
 						found = true
 					}
 				}
@@ -780,7 +792,7 @@ func validateImage(t *testing.T, img oci.SignedImage, baseLayers int64, creation
 	})
 
 	t.Run("check annotations", func(t *testing.T) {
-		if !checkAnnotations {
+		if !opts.checkAnnotations {
 			t.Skip("skipping annotations check")
 		}
 		mf, err := img.Manifest()
@@ -797,7 +809,7 @@ func validateImage(t *testing.T, img oci.SignedImage, baseLayers int64, creation
 		}
 	})
 
-	if expectSBOM {
+	if opts.expectSBOM {
 		t.Run("checking for SBOM", func(t *testing.T) {
 			f, err := img.Attachment("sbom")
 			if err != nil {
@@ -860,7 +872,7 @@ func TestGoBuild(t *testing.T) {
 		t.Fatalf("Build() not a SignedImage: %T", result)
 	}
 
-	validateImage(t, img, baseLayers, creationTime, true, true)
+	validateImage(t, img, baseLayers, creationTime, validationOptions{checkAnnotations: true, expectSBOM: true})
 
 	// Check that rebuilding the image again results in the same image digest.
 	t.Run("check determinism", func(t *testing.T) {
@@ -1068,7 +1080,82 @@ func TestGoBuildWithoutSBOM(t *testing.T) {
 		t.Fatalf("Build() not a SignedImage: %T", result)
 	}
 
-	validateImage(t, img, baseLayers, creationTime, true, false)
+	validateImage(t, img, baseLayers, creationTime, validationOptions{checkAnnotations: true, expectSBOM: false})
+}
+
+func TestGoBuild_WithAppDir(t *testing.T) {
+	baseLayers := int64(3)
+	base, err := random.Image(1024, baseLayers)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	importpath := "github.com/google/ko"
+
+	creationTime := v1.Time{Time: time.Unix(5000, 0)}
+	ng, err := NewGo(
+		context.Background(),
+		"",
+		WithCreationTime(creationTime),
+		WithBaseImages(func(context.Context, string) (name.Reference, Result, error) { return baseRef, base, nil }),
+		withBuilder(writeTempFile),
+		withSBOMber(fauxSBOM),
+		WithLabel("foo", "bar"),
+		WithLabel("hello", "world"),
+		WithPlatforms("all"),
+		WithAppDir("/usr/local/bin"),
+	)
+	if err != nil {
+		t.Fatalf("NewGo() = %v", err)
+	}
+
+	result, err := ng.Build(context.Background(), StrictScheme+filepath.Join(importpath, "test"))
+	if err != nil {
+		t.Fatalf("Build() = %v", err)
+	}
+
+	img, ok := result.(oci.SignedImage)
+	if !ok {
+		t.Fatalf("Build() not a SignedImage: %T", result)
+	}
+
+	validateImage(t, img, baseLayers, creationTime, validationOptions{checkAnnotations: true, expectSBOM: true, entryPointBasePath: "/usr/local/bin"})
+
+	// Check that rebuilding the image again results in the same image digest.
+	t.Run("check determinism", func(t *testing.T) {
+		result2, err := ng.Build(context.Background(), StrictScheme+filepath.Join(importpath, "test"))
+		if err != nil {
+			t.Fatalf("Build() = %v", err)
+		}
+
+		d1, err := result.Digest()
+		if err != nil {
+			t.Fatalf("Digest() = %v", err)
+		}
+		d2, err := result2.Digest()
+		if err != nil {
+			t.Fatalf("Digest() = %v", err)
+		}
+
+		if d1 != d2 {
+			t.Errorf("Digest mismatch: %s != %s", d1, d2)
+		}
+	})
+
+	t.Run("check labels", func(t *testing.T) {
+		cfg, err := img.ConfigFile()
+		if err != nil {
+			t.Fatalf("ConfigFile() = %v", err)
+		}
+
+		want := map[string]string{
+			"foo":   "bar",
+			"hello": "world",
+		}
+		got := cfg.Config.Labels
+		if d := cmp.Diff(got, want); d != "" {
+			t.Fatalf("Labels diff (-got,+want): %s", d)
+		}
+	})
 }
 
 func TestGoBuildIndex(t *testing.T) {
@@ -1114,7 +1201,7 @@ func TestGoBuildIndex(t *testing.T) {
 		if err != nil {
 			t.Fatalf("idx.Image(%s) = %v", desc.Digest, err)
 		}
-		validateImage(t, img, baseLayers, creationTime, false, true)
+		validateImage(t, img, baseLayers, creationTime, validationOptions{checkAnnotations: false, expectSBOM: true})
 	}
 
 	if want, got := images, int64(len(im.Manifests)); want != got {
@@ -1497,6 +1584,63 @@ func TestDebugger(t *testing.T) {
 		"--accept-multiclient",
 		"--api-version=2",
 		"/ko-app/ko",
+	}
+
+	if got, want := len(gotEntrypoint), len(wantEntrypoint); got != want {
+		t.Fatalf("len(entrypoint) = %v, want %v", got, want)
+	}
+
+	for i := range wantEntrypoint {
+		if got, want := gotEntrypoint[i], wantEntrypoint[i]; got != want {
+			t.Errorf("entrypoint[%d] = %v, want %v", i, got, want)
+		}
+	}
+}
+
+func TestDebugger_WithAppDirOverwrite(t *testing.T) {
+	base, err := random.Image(1024, 3)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	importpath := "github.com/google/ko"
+
+	ng, err := NewGo(
+		context.Background(),
+		"",
+		WithBaseImages(func(context.Context, string) (name.Reference, Result, error) { return baseRef, base, nil }),
+		WithPlatforms("linux/amd64"),
+		WithAppDir("/usr/local/bin"),
+		WithDebugger(),
+	)
+	if err != nil {
+		t.Fatalf("NewGo() = %v", err)
+	}
+
+	result, err := ng.Build(context.Background(), StrictScheme+importpath)
+	if err != nil {
+		t.Fatalf("Build() = %v", err)
+	}
+
+	img, ok := result.(v1.Image)
+	if !ok {
+		t.Fatalf("Build() not an Image: %T", result)
+	}
+
+	// Check that the entrypoint of the image is not overwritten
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		t.Errorf("ConfigFile() = %v", err)
+	}
+	gotEntrypoint := cfg.Config.Entrypoint
+	wantEntrypoint := []string{
+		"/usr/local/bin/dlv",
+		"exec",
+		"--listen=:40000",
+		"--headless",
+		"--log",
+		"--accept-multiclient",
+		"--api-version=2",
+		"/usr/local/bin/ko",
 	}
 
 	if got, want := len(gotEntrypoint), len(wantEntrypoint); got != want {

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -191,3 +191,10 @@ func WithDebugger() Option {
 		return nil
 	}
 }
+
+func WithAppDir(dir string) Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.appDir = dir
+		return nil
+	}
+}

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -59,6 +59,10 @@ type BuildOptions struct {
 	// Empty string means the current working directory.
 	WorkingDirectory string
 
+	// AppDirectory allows for setting where the Go application binaries will be placed in the resulting container.
+	// Empty string means the default directly /ko-app.
+	AppDirectory string
+
 	ConcurrentBuilds     int
 	DisableOptimizations bool
 	SBOM                 string
@@ -97,6 +101,8 @@ func AddBuildOptions(cmd *cobra.Command, bo *BuildOptions) {
 		"Which labels (key=value) to add to the image.")
 	cmd.Flags().BoolVar(&bo.Debug, "debug", bo.Debug,
 		"Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.")
+	cmd.Flags().StringVar(&bo.AppDirectory, "app-dir", "",
+		"Directory the application binaries should be placed inside the container instead of default /ko-app.")
 	bo.Trimpath = true
 }
 
@@ -166,6 +172,12 @@ func (bo *BuildOptions) LoadConfig() error {
 			return fmt.Errorf("'defaultBaseImage': error parsing %q as image reference: %w", ref, err)
 		}
 		bo.BaseImage = ref
+	}
+
+	if bo.AppDirectory == "" {
+		if appDir := v.GetString("defaultAppDirectory"); appDir != "" {
+			bo.AppDirectory = appDir
+		}
 	}
 
 	if len(bo.BaseImageOverrides) == 0 {

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -128,6 +128,10 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		opts = append(opts, build.WithSBOMDir(bo.SBOMDir))
 	}
 
+	if bo.AppDirectory != "" {
+		opts = append(opts, build.WithAppDir(bo.AppDirectory))
+	}
+
 	return opts, nil
 }
 


### PR DESCRIPTION
This PR proposes a way to allow optionally modifying under which path binaries are placed inside containers built with ko - as raised in issue #944 

Without deeper insight into the code base, this seems like a straightforward addition with limited impact on future maintainability to me - while allowing users migrating to ko to still place binaries in the same location as their previous Docker containers.

Looking forward to your input and any suggestions! 