### PR TITLE
feat: add ko test command to build with go test -c

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -89,3 +89,7 @@ jobs:
           # Check that --debug adds dlv to the image, and that dlv is runnable.
           docker run --entrypoint="dlv" $(go run ./ build ./test/ --platform=${PLATFORM} --debug) version | grep "Delve Debugger"
         fi
+
+        # Build and run tests in the test/ folder
+        testimg=$(go run ./ test ./test/test/ --platform=${PLATFORM})
+        docker run ${testimg} | grep "PASS"

--- a/docs/reference/ko.md
+++ b/docs/reference/ko.md
@@ -22,5 +22,6 @@ ko [flags]
 * [ko login](ko_login.md)	 - Log in to a registry
 * [ko resolve](ko_resolve.md)	 - Print the input files with image references resolved to built/pushed image digests.
 * [ko run](ko_run.md)	 - A variant of `kubectl run` that containerizes IMPORTPATH first.
+* [ko test](ko_test.md)	 - Build and publish container images with go test from the given importpaths.
 * [ko version](ko_version.md)	 - Print ko version.
 

--- a/docs/reference/ko_test.md
+++ b/docs/reference/ko_test.md
@@ -1,0 +1,75 @@
+## ko test
+
+Build and publish container images with go test from the given importpaths.
+
+### Synopsis
+
+This sub-command builds the provided import paths into Go test binaries, containerizes them, and publishes them.
+
+```
+ko test IMPORTPATH... [flags]
+```
+
+### Examples
+
+```
+
+  # Build and publish tests from import path references to a Docker Registry as:
+  #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if --local and
+  # --preserve-import-paths were passed.
+  # If the import path is not provided, the current working directory is the
+  # default.
+  ko test github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah
+
+  # Build and publish tests from a relative import path as:
+  #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if --local and
+  # --preserve-import-paths were passed.
+  ko test ./cmd/blah
+
+  # Build and publish tests from a relative import path as:
+  #   ${KO_DOCKER_REPO}/<import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if --local was passed.
+  ko test --preserve-import-paths ./cmd/blah
+
+  # Build and publish tests from import path references to a Docker daemon as:
+  #   ko.local/<import path>
+  # This always preserves import paths.
+  ko test --local github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah
+```
+
+### Options
+
+```
+      --bare                     Whether to just use KO_DOCKER_REPO without additional context (may not work properly with --tags).
+  -B, --base-import-paths        Whether to use the base path without MD5 hash after KO_DOCKER_REPO (may not work properly with --tags).
+      --debug                    Include Delve debugger into image and wrap around ko-app. This debugger will listen to port 40000.
+      --disable-optimizations    Disable optimizations when building Go code. Useful when you want to interactively debug the created container.
+  -h, --help                     help for test
+      --image-label strings      Which labels (key=value) to add to the image.
+      --image-refs string        Path to file where a list of the published image references will be written.
+      --insecure-registry        Whether to skip TLS verification on the registry
+  -j, --jobs int                 The maximum number of concurrent builds (default GOMAXPROCS)
+  -L, --local                    Load into images to local docker daemon.
+      --oci-layout-path string   Path to save the OCI image layout of the built images
+      --platform strings         Which platform to use when pulling a multi-platform base. Format: all | <os>[/<arch>[/<variant>]][,platform]*
+  -P, --preserve-import-paths    Whether to preserve the full import path after KO_DOCKER_REPO.
+      --push                     Push images to KO_DOCKER_REPO (default true)
+      --sbom string              The SBOM media type to use (none will disable SBOM synthesis and upload). (default "spdx")
+      --sbom-dir string          Path to file where the SBOM will be written.
+      --tag-only                 Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
+  -t, --tags strings             Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
+      --tarball string           File to save images tarballs
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable debug logs
+```
+
+### SEE ALSO
+
+* [ko](ko.md)	 - Rapidly iterate with Go, Containers, and Kubernetes.
+

--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -76,6 +76,10 @@ type Config struct {
 	Ldflags StringArray `yaml:",omitempty"`
 	Flags   FlagArray   `yaml:",omitempty"`
 
+	// TestLdflags and TestFlags will be used for the Go test command line arguments
+	TestLdflags StringArray `yaml:",omitempty"`
+	TestFlags   FlagArray   `yaml:",omitempty"`
+
 	// Env allows setting environment variables for `go build`
 	Env []string `yaml:",omitempty"`
 

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -210,3 +210,10 @@ func WithDebugger() Option {
 		return nil
 	}
 }
+
+func WithGoTest() Option {
+	return func(gbo *gobuildOpener) error {
+		gbo.goTest = true
+		return nil
+	}
+}

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -32,6 +32,7 @@ func AddKubeCommands(topLevel *cobra.Command) {
 	addResolve(topLevel)
 	addBuild(topLevel)
 	addRun(topLevel)
+	addTest(topLevel)
 }
 
 // check if kubectl is installed

--- a/pkg/commands/options/build.go
+++ b/pkg/commands/options/build.go
@@ -68,6 +68,7 @@ type BuildOptions struct {
 	Annotations          []string
 	User                 string
 	Debug                bool
+	GoTest               bool
 	// UserAgent enables overriding the default value of the `User-Agent` HTTP
 	// request header used when retrieving the base image.
 	UserAgent string

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -105,6 +105,9 @@ func gobuildOptions(bo *options.BuildOptions) ([]build.Option, error) {
 		opts = append(opts, build.WithDebugger())
 		opts = append(opts, build.WithDisabledOptimizations()) // also needed for Delve
 	}
+	if bo.GoTest {
+		opts = append(opts, build.WithGoTest())
+	}
 	switch bo.SBOM {
 	case "none":
 		opts = append(opts, build.WithDisabledSBOM())

--- a/pkg/commands/test.go
+++ b/pkg/commands/test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ko Build Authors All Rights Reserved.
+// Copyright 2024 ko Build Authors All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/commands/test.go
+++ b/pkg/commands/test.go
@@ -1,0 +1,94 @@
+// Copyright 2018 ko Build Authors All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/google/ko/pkg/commands/options"
+	"github.com/spf13/cobra"
+)
+
+// addBuild augments our CLI surface with build.
+func addTest(topLevel *cobra.Command) {
+	po := &options.PublishOptions{}
+	bo := &options.BuildOptions{}
+
+	build := &cobra.Command{
+		Use:     "test IMPORTPATH...",
+		Short:   "Build and publish container images with go test from the given importpaths.",
+		Long:    `This sub-command builds the provided import paths into Go test binaries, containerizes them, and publishes them.`,
+		Aliases: []string{"publish"},
+		Example: `
+  # Build and publish tests from import path references to a Docker Registry as:
+  #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if --local and
+  # --preserve-import-paths were passed.
+  # If the import path is not provided, the current working directory is the
+  # default.
+  ko test github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah
+
+  # Build and publish tests from a relative import path as:
+  #   ${KO_DOCKER_REPO}/<package name>-<hash of import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if --local and
+  # --preserve-import-paths were passed.
+  ko test ./cmd/blah
+
+  # Build and publish tests from a relative import path as:
+  #   ${KO_DOCKER_REPO}/<import path>
+  # When KO_DOCKER_REPO is ko.local, it is the same as if --local was passed.
+  ko test --preserve-import-paths ./cmd/blah
+
+  # Build and publish tests from import path references to a Docker daemon as:
+  #   ko.local/<import path>
+  # This always preserves import paths.
+  ko test --local github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.Validate(po, bo); err != nil {
+				return fmt.Errorf("validating options: %w", err)
+			}
+
+			if len(args) == 0 {
+				// Build the current directory by default.
+				args = []string{"."}
+			}
+
+			ctx := cmd.Context()
+
+			bo.GoTest = true
+			bo.InsecureRegistry = po.InsecureRegistry
+			builder, err := makeBuilder(ctx, bo)
+			if err != nil {
+				return fmt.Errorf("error creating builder: %w", err)
+			}
+			publisher, err := makePublisher(po)
+			if err != nil {
+				return fmt.Errorf("error creating publisher: %w", err)
+			}
+			defer publisher.Close()
+			images, err := publishImages(ctx, args, publisher, builder)
+			if err != nil {
+				return fmt.Errorf("failed to publish images: %w", err)
+			}
+			for _, img := range images {
+				fmt.Println(img)
+			}
+			return nil
+		},
+	}
+	options.AddPublishArg(build, po)
+	options.AddBuildOptions(build, bo)
+	topLevel.AddCommand(build)
+}

--- a/test/test/dummy_test.go
+++ b/test/test/dummy_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 ko Build Authors All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package test
 
 import "testing"

--- a/test/test/dummy_test.go
+++ b/test/test/dummy_test.go
@@ -1,0 +1,9 @@
+package test
+
+import "testing"
+
+func TestDummy(t *testing.T) {
+	t.Run("dummy test", func(t *testing.T) {
+		t.Logf("this is a dummy test")
+	})
+}

--- a/test/test/empty_test.go
+++ b/test/test/empty_test.go
@@ -16,8 +16,8 @@ package test
 
 import "testing"
 
-func TestDummy(t *testing.T) {
-	t.Run("dummy test", func(t *testing.T) {
-		t.Logf("this is a dummy test")
+func TestEmpty(t *testing.T) {
+	t.Run("empty test", func(t *testing.T) {
+		t.Logf("this is an empty test")
 	})
 }


### PR DESCRIPTION
Add a new command to build images with the output of go test -c.

It allows configuring build and LD flags in .ko.yaml with different values for build and test commands for a given importpath.

This is a new attempt at implementing #96 with a separate command.