### PR TITLE
Remove remaining references to `vendor/`

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -58,7 +58,6 @@ jobs:
           fail_on_error: true
           locale: "US"
           exclude: |
-            ./vendor/*
             ./.golangci.yaml
 
       - uses: get-woke/woke-action-reviewdog@d71fd0115146a01c3181439ce714e21a69d75e31 # v0

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 ko
 
 .DS_Store
+
+/vendor/

--- a/.wokeignore
+++ b/.wokeignore
@@ -1,4 +1,2 @@
-vendor/**
-
 # Uses some Cobra methods
 pkg/commands/*

--- a/hack/presubmit.sh
+++ b/hack/presubmit.sh
@@ -24,7 +24,7 @@ pushd "${PROJECT_ROOT}"
 trap popd EXIT
 
 # Verify that all source files are correctly formatted.
-find . -name "*.go" | grep -v vendor/ | xargs gofmt -d -e -l
+find . -name "*.go" -exec gofmt -d -e -l {} +
 
 # Verify that generated Markdown docs are up-to-date.
 tmpdir=$(mktemp -d)

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -24,6 +24,5 @@ pushd ${PROJECT_ROOT}
 trap popd EXIT
 
 go mod tidy
-go mod vendor
 
 go run $PROJECT_ROOT/cmd/help/main.go --dir=$PROJECT_ROOT/docs/reference/

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -24,9 +24,3 @@ pushd ${PROJECT_ROOT}
 trap popd EXIT
 
 go mod tidy
-go mod vendor
-
-# Delete all vendored broken symlinks.
-# From https://stackoverflow.com/questions/22097130/delete-all-broken-symbolic-links-with-a-line
-find vendor/ -type l -exec sh -c 'for x; do [ -e "$x" ] || rm "$x"; done' _ {} +
-


### PR DESCRIPTION
The vendor directory was removed in 38a1feb0, but it lives on in some places (largely development/contribution and linting).  This change removes those remaining references.