### PR TITLE
Pin the version of ko we use to release ko

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
 
       # This installs the current latest release.
       - uses: ko-build/setup-ko@3aebd0597dc1e9d1a26bcfdb7cbeb19c131d3037 # v0.7
+        with:
+          # This MUST be pinned or we have a dependency cycle!
+          version: v0.16.0
 
       - uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 


### PR DESCRIPTION
Otherwise it creates a dependency cycle.

This was removed here: https://github.com/ko-build/ko/commit/61a6c202c83ee2d7480abf590b861c419ba3b58f