### PR TITLE
Remove cycle in release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,10 @@ jobs:
           go-version-file: 'go.mod'
           check-latest: true
 
-      # This installs the current latest release.
+      # This installs the current latest release. We have to manually bump this.
       - uses: ko-build/setup-ko@3aebd0597dc1e9d1a26bcfdb7cbeb19c131d3037 # v0.7
+        with:
+          version: v0.16.0 # DO NOT REMOVE THIS OR IT WILL CREATE A CYCLE.
 
       - uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 


### PR DESCRIPTION
We can't use the latest release to build the latest release.