### PR TITLE
fix(formatting): Updated the codeblock for Dockerfile to make it more readable

### DIFF
--- a/docs/advanced/migrating-from-dockerfile.md
+++ b/docs/advanced/migrating-from-dockerfile.md
@@ -4,12 +4,8 @@ If your `Dockerfile` looks like either of the examples in the [official tutorial
 
 Let's review the best practice multi-stage Dockerfile in that tutorial first:
 
-```plaintext
-# syntax=docker/dockerfile:1
-
-##
+```Dockerfile
 ## Build
-##
 FROM golang:1.16-buster AS build
 
 WORKDIR /app
@@ -22,9 +18,7 @@ COPY *.go ./
 
 RUN go build -o /docker-gs-ping
 
-##
 ## Deploy
-##
 FROM gcr.io/distroless/base-debian10
 
 WORKDIR /


### PR DESCRIPTION
The Dockerfile example, whilst not functional at all, is not readable with the current formatting applies

This PR updates the formatting on the mkdocs site

![image](https://github.com/user-attachments/assets/d5bf81ae-f0e7-4971-b8a5-524f1b3a1e41)
