### PR TITLE
fix(debug): ensure reproducible builds in debug mode

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -331,6 +331,8 @@ func getDelve(ctx context.Context, platform v1.Platform) (string, error) {
 	// install delve to tmp directory
 	args := []string{
 		"build",
+		"-trimpath",
+		"-ldflags=-s -w",
 		"-o",
 		delveBinaryPath,
 		"./cmd/dlv",


### PR DESCRIPTION
When use `--debug` build flag, a new dlv executable file is built into the image. However, during the build, some build flags are not specified, resulting in the binary being different each time, which ultimately causes the digest of the image to be inconsistent.

This change aims to ensure that, as long as the remote dlv code has not been updated, the digest remains consistent with each build.