### PR TITLE
Adding labels to make it easier k8s.md

### DIFF
--- a/docs/features/k8s.md
+++ b/docs/features/k8s.md
@@ -17,9 +17,13 @@ kind: Deployment
 metadata:
   name: my-deployment
 spec:
-  replicas: 3
-  ...
+  selector:
+    matchLabels:
+      app: my-app
   template:
+    metadata:
+      labels:
+        app: my-app
     spec:
       containers:
       - name: my-app


### PR DESCRIPTION
When trying out these examples, it is easier to have a deployment that can be copied and quickly tested. I don't think it adds too much clutter and it definitely saves people to troubleshoot why what they copied from the site doesn't work.