### PR TITLE
Update ko version used in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       # This installs the current latest release. We have to manually bump this.
       - uses: ko-build/setup-ko@3aebd0597dc1e9d1a26bcfdb7cbeb19c131d3037 # v0.7
         with:
-          version: v0.17.1 # DO NOT REMOVE THIS OR IT WILL CREATE A CYCLE.
+          version: v0.18.0 # DO NOT REMOVE THIS OR IT WILL CREATE A CYCLE.
 
       - uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       # This installs the current latest release. We have to manually bump this.
       - uses: ko-build/setup-ko@3aebd0597dc1e9d1a26bcfdb7cbeb19c131d3037 # v0.7
         with:
-          version: v0.16.0 # DO NOT REMOVE THIS OR IT WILL CREATE A CYCLE.
+          version: v0.17.1 # DO NOT REMOVE THIS OR IT WILL CREATE A CYCLE.
 
       - uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
 


### PR DESCRIPTION
We noticed that using the ko docker image it is currently not possible to build projects that specify the latest go version in their `go.mod`:
```
docker run -v .:/tmp/demo -w /tmp/demo ghcr.io/ko-build/ko:v0.17.1 build . --push=false 
Error: failed to publish images: qualifying local import : err: exit status 1: stderr: go: go.mod requires go >= 1.24.0 (running go 1.23.2; GOTOOLCHAIN=local)
```

I guess all that would be needed is to just create a new release, that rebuilds the images, since the ko image always uses the [latest golang image as its base](https://github.com/maboehm/ko/blob/f7d9dd7717cb3b1ba46576ade1f85f233ccb1a73/.ko.yaml#L2).
To prepare that it probably makes sense to run the tests against these versions, and then a new release could be published.