### PR TITLE
Revert "drop -m flag" to fix empty SBOM generation in `v0.18.0`

### DIFF
--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -464,13 +464,11 @@ func goversionm(ctx context.Context, file string, appPath string, appFileName st
 	switch se.(type) {
 	case oci.SignedImage:
 		sbom := bytes.NewBuffer(nil)
-		// seems in go1.24 the -m flag breaks things
-		// tested with go1.23 and works, but starting with go1.24.0 it breaks
-		cmd := exec.CommandContext(ctx, gobin, "version", file)
+		cmd := exec.CommandContext(ctx, gobin, "version", "-m", file)
 		cmd.Stdout = sbom
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			return nil, "", fmt.Errorf("go version %s: %w", file, err)
+			return nil, "", fmt.Errorf("go version -m %s: %w", file, err)
 		}
 
 		// In order to get deterministics SBOMs replace our randomized

--- a/pkg/build/gobuilds_test.go
+++ b/pkg/build/gobuilds_test.go
@@ -31,6 +31,7 @@ func Test_gobuilds(t *testing.T) {
 	opts := []Option{
 		WithBaseImages(func(context.Context, string) (name.Reference, Result, error) { return baseRef, base, nil }),
 		withBuilder(writeTempFile),
+		withSBOMber(fauxSBOM),
 		WithPlatforms("all"),
 	}
 


### PR DESCRIPTION
This reverts commit 3f2f5a5d2c4482a80ba2a11af9f9021d0190f247.

Since `ko v0.18.0`, mostly empty SBOMs have been generated. While investigating the cause of this, I noticed that the `-m` flag was removed from `go version -m` by commit 3f2f5a5d2c4482a80ba2a11af9f9021d0190f247. If the `-m` flag is not specified, module versions are not outputted, resulting in the generation of SBOMs that do not include module information.

> $ go help version
> usage: go version [-m] [-v] [file ...]
> [...]
> The -m flag causes go version to print each file's embedded
> module version information, when available. In the output, the module
> information consists of multiple lines following the version line, each
> indented by a leading tab character.


This PR resolves this issue by reverting the commit that removed the `-m` flag. As far as I tested, the output of `go version -m` did not differ between Go 1.23 and Go 1.24.0.