### PR TITLE
Follow symlinked dirs in recursive file mode

### DIFF
--- a/pkg/commands/options/filestuff.go
+++ b/pkg/commands/options/filestuff.go
@@ -48,42 +48,73 @@ func EnumerateFiles(fo *FilenameOptions) chan string {
 				files <- paths
 				continue
 			}
-			// For each of the "filenames" we are passed (file or directory) start a
-			// "Walk" to enumerate all of the contained files recursively.
-			err := filepath.Walk(paths, func(path string, fi os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-
-				// If this is a directory, skip it if it isn't the current directory we are
-				// processing (unless we are in recursive mode).  If we decide to process
-				// the directory, and we're in watch mode, then we set up a watch on the
-				// directory.
-				if fi.IsDir() {
-					if path != paths && !fo.Recursive {
-						return filepath.SkipDir
-					}
-					// We don't stream back directories, we just decide to skip them, or not.
-					return nil
-				}
-
-				// Don't check extension if the filepath was passed explicitly
-				if path != paths {
-					switch filepath.Ext(path) {
-					case ".json", ".yaml":
-						// Process these.
-					default:
-						return nil
-					}
-				}
-
-				files <- path
-				return nil
-			})
-			if err != nil {
+			if err := enumerateFiles(paths, paths, fo.Recursive, map[string]struct{}{}, files); err != nil {
 				log.Fatalf("Error enumerating files: %v", err)
 			}
 		}
 	}()
 	return files
+}
+
+func enumerateFiles(root, filename string, recursive bool, visited map[string]struct{}, files chan<- string) error {
+	fi, err := os.Lstat(filename)
+	if err != nil {
+		return err
+	}
+
+	isDir := fi.IsDir()
+	if fi.Mode()&os.ModeSymlink != 0 {
+		targetInfo, err := os.Stat(filename)
+		if err != nil {
+			// Preserve the old behavior for file-like symlinks: if the entry was
+			// passed explicitly, stream it and let later file handling report errors.
+			if filename == root {
+				files <- filename
+			}
+			return nil
+		}
+		isDir = targetInfo.IsDir()
+	}
+
+	if isDir {
+		if filename != root && !recursive {
+			return nil
+		}
+		resolved, err := filepath.EvalSymlinks(filename)
+		if err != nil {
+			return err
+		}
+		abs, err := filepath.Abs(resolved)
+		if err != nil {
+			return err
+		}
+		if _, ok := visited[abs]; ok {
+			return nil
+		}
+		visited[abs] = struct{}{}
+
+		entries, err := os.ReadDir(filename)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if err := enumerateFiles(root, filepath.Join(filename, entry.Name()), recursive, visited, files); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Don't check extension if the filepath was passed explicitly.
+	if filename != root {
+		switch filepath.Ext(filename) {
+		case ".json", ".yaml":
+			// Process these.
+		default:
+			return nil
+		}
+	}
+
+	files <- filename
+	return nil
 }

--- a/pkg/commands/options/filestuff.go
+++ b/pkg/commands/options/filestuff.go
@@ -66,14 +66,12 @@ func enumerateFiles(root, filename string, recursive bool, visited map[string]st
 	if fi.Mode()&os.ModeSymlink != 0 {
 		targetInfo, err := os.Stat(filename)
 		if err != nil {
-			// Preserve the old behavior for file-like symlinks: if the entry was
-			// passed explicitly, stream it and let later file handling report errors.
-			if filename == root {
-				files <- filename
-			}
-			return nil
+			// Preserve the old behavior for file-like symlinks: stream matching
+			// entries and let later file handling report broken targets.
+			isDir = false
+		} else {
+			isDir = targetInfo.IsDir()
 		}
-		isDir = targetInfo.IsDir()
 	}
 
 	if isDir {

--- a/pkg/commands/options/filestuff_test.go
+++ b/pkg/commands/options/filestuff_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 ko Build Authors All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestEnumerateFilesRecursiveFollowsSymlinkedDirectory(t *testing.T) {
+	root := t.TempDir()
+	target := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(target, "deployment.yaml"), []byte("kind: Deployment\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "ignored.txt"), []byte("ignored\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(root, "linked")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("skipping symlink test: %v", err)
+	}
+
+	got := collectFiles(&FilenameOptions{Filenames: []string{root}, Recursive: true})
+	want := []string{filepath.Join(link, "deployment.yaml")}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("EnumerateFiles() = %v, want %v", got, want)
+	}
+}
+
+func TestEnumerateFilesRecursiveFollowsSymlinkedRootDirectory(t *testing.T) {
+	target := t.TempDir()
+	link := filepath.Join(t.TempDir(), "linked")
+
+	if err := os.WriteFile(filepath.Join(target, "service.yaml"), []byte("kind: Service\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("skipping symlink test: %v", err)
+	}
+
+	got := collectFiles(&FilenameOptions{Filenames: []string{link}, Recursive: true})
+	want := []string{filepath.Join(link, "service.yaml")}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("EnumerateFiles() = %v, want %v", got, want)
+	}
+}
+
+func TestEnumerateFilesNonRecursiveSkipsSymlinkedSubdirectory(t *testing.T) {
+	root := t.TempDir()
+	target := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(target, "deployment.yaml"), []byte("kind: Deployment\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(root, "linked")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("skipping symlink test: %v", err)
+	}
+
+	got := collectFiles(&FilenameOptions{Filenames: []string{root}})
+	if len(got) != 0 {
+		t.Fatalf("EnumerateFiles() = %v, want no files", got)
+	}
+}
+
+func collectFiles(fo *FilenameOptions) []string {
+	got := make([]string, 0)
+	for file := range EnumerateFiles(fo) {
+		got = append(got, file)
+	}
+	sort.Strings(got)
+	return got
+}

--- a/pkg/commands/options/filestuff_test.go
+++ b/pkg/commands/options/filestuff_test.go
@@ -82,6 +82,20 @@ func TestEnumerateFilesNonRecursiveSkipsSymlinkedSubdirectory(t *testing.T) {
 	}
 }
 
+func TestEnumerateFilesRecursiveKeepsBrokenManifestSymlink(t *testing.T) {
+	root := t.TempDir()
+	link := filepath.Join(root, "broken.yaml")
+	if err := os.Symlink(filepath.Join(root, "missing.yaml"), link); err != nil {
+		t.Skipf("skipping symlink test: %v", err)
+	}
+
+	got := collectFiles(&FilenameOptions{Filenames: []string{root}, Recursive: true})
+	want := []string{link}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("EnumerateFiles() = %v, want %v", got, want)
+	}
+}
+
 func collectFiles(fo *FilenameOptions) []string {
 	got := make([]string, 0)
 	for file := range EnumerateFiles(fo) {


### PR DESCRIPTION
## Summary
- Teach recursive filename enumeration to descend into symlinked directories.
- Keep non-recursive traversal from entering nested symlinked directories.
- Add unit coverage for symlinked directory roots and nested symlinked directories.

Fixes #460

## Validation
- `go test ./pkg/commands/options -run 'TestEnumerateFiles.*Symlinked' -count=1`
- `go test ./pkg/commands/options -count=1`
- `go test ./pkg/commands/... -count=1`
- `go vet ./pkg/commands/...`
- `git diff --check`