### PR TITLE
docs(cli): note --tarball is single-platform-only

### DIFF
--- a/docs/reference/ko_apply.md
+++ b/docs/reference/ko_apply.md
@@ -69,7 +69,7 @@ ko apply -f FILENAME [flags]
   -l, --selector string            Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
       --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string             File to save images tarballs
+      --tarball string             File to save Docker-save-style image tarballs. Only single-platform images are supported; multi-platform image indexes are not, use --oci-layout-path for multi-platform output.
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_build.md
+++ b/docs/reference/ko_build.md
@@ -63,7 +63,7 @@ ko build IMPORTPATH... [flags]
       --sbom-dir string            Path to directory where the SBOM will be written.
       --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string             File to save images tarballs
+      --tarball string             File to save Docker-save-style image tarballs. Only single-platform images are supported; multi-platform image indexes are not, use --oci-layout-path for multi-platform output.
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_create.md
+++ b/docs/reference/ko_create.md
@@ -69,7 +69,7 @@ ko create -f FILENAME [flags]
   -l, --selector string            Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
       --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string             File to save images tarballs
+      --tarball string             File to save Docker-save-style image tarballs. Only single-platform images are supported; multi-platform image indexes are not, use --oci-layout-path for multi-platform output.
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_resolve.md
+++ b/docs/reference/ko_resolve.md
@@ -62,7 +62,7 @@ ko resolve -f FILENAME [flags]
   -l, --selector string            Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
       --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string             File to save images tarballs
+      --tarball string             File to save Docker-save-style image tarballs. Only single-platform images are supported; multi-platform image indexes are not, use --oci-layout-path for multi-platform output.
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/ko_run.md
+++ b/docs/reference/ko_run.md
@@ -51,7 +51,7 @@ ko run IMPORTPATH [flags]
       --sbom-dir string            Path to directory where the SBOM will be written.
       --tag-only                   Include tags but not digests in resolved image references. Useful when digests are not preserved when images are repopulated.
   -t, --tags strings               Which tags to use for the produced image instead of the default 'latest' tag (may not work properly with --base-import-paths or --bare). (default [latest])
-      --tarball string             File to save images tarballs
+      --tarball string             File to save Docker-save-style image tarballs. Only single-platform images are supported; multi-platform image indexes are not, use --oci-layout-path for multi-platform output.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/commands/options/publish.go
+++ b/pkg/commands/options/publish.go
@@ -93,7 +93,8 @@ func AddPublishArg(cmd *cobra.Command, po *PublishOptions) {
 		"Whether to skip TLS verification on the registry")
 
 	cmd.Flags().StringVar(&po.OCILayoutPath, "oci-layout-path", "", "Path to save the OCI image layout of the built images")
-	cmd.Flags().StringVar(&po.TarballFile, "tarball", "", "File to save images tarballs")
+	cmd.Flags().StringVar(&po.TarballFile, "tarball", "",
+		"File to save Docker-save-style image tarballs. Only single-platform images are supported; multi-platform image indexes are not, use --oci-layout-path for multi-platform output.")
 
 	cmd.Flags().StringVar(&po.ImageRefsFile, "image-refs", "",
 		"Path to file where a list of the published image references will be written.")


### PR DESCRIPTION
Fixes #1708.

The `--tarball` flag description used to be just "File to save images tarballs", which reads like it works with the same multi-platform builds `ko` otherwise supports. The tarball publisher only handles `v1.Image` (single-platform), not `v1.ImageIndex` — see `pkg/publish/tarball.go`, which downcasts the build result and rejects an image index with the comment "there is no way to write an index to a tarball".

## Change

Extend the flag help to:
1. Name the format (Docker-save-style),
2. State the single-platform limitation,
3. Point users to `--oci-layout-path` for multi-platform output.

Regenerated the affected docs under `docs/reference/` via `./hack/update-codegen.sh`. No code behaviour change.

## Verification

- `./hack/presubmit.sh` — clean
- `go test ./pkg/commands/options/...` — pass
