### PR TITLE
Fix kind.Write goroutine leak when image import fails

### DIFF
--- a/pkg/publish/kind/write.go
+++ b/pkg/publish/kind/write.go
@@ -73,7 +73,7 @@ func Write(ctx context.Context, tag name.Tag, img v1.Image) error {
 		cmd.SetStdout(&buf)
 		cmd.SetStderr(&buf)
 		err := cmd.Run()
-		// Unblock tarball.Write if the importer stopped reading (failed or cancelled).
+		// Unblock tarball.Write if the importer stopped reading (failed or canceled).
 		pr.Close()
 		waitErr := grp.Wait()
 		if err != nil {

--- a/pkg/publish/kind/write.go
+++ b/pkg/publish/kind/write.go
@@ -65,7 +65,10 @@ func Write(ctx context.Context, tag name.Tag, img v1.Image) error {
 
 		grp := errgroup.Group{}
 		grp.Go(func() error {
-			return pw.CloseWithError(tarball.Write(tag, img, pw))
+			// CloseWithError always returns nil; return the Write error so Wait surfaces it.
+			err := tarball.Write(tag, img, pw)
+			pw.CloseWithError(err)
+			return err
 		})
 
 		var buf bytes.Buffer

--- a/pkg/publish/kind/write.go
+++ b/pkg/publish/kind/write.go
@@ -72,12 +72,15 @@ func Write(ctx context.Context, tag name.Tag, img v1.Image) error {
 		cmd := n.CommandContext(ctx, "ctr", "--namespace=k8s.io", "images", "import", "--all-platforms", "-").SetStdin(pr)
 		cmd.SetStdout(&buf)
 		cmd.SetStderr(&buf)
-		if err := cmd.Run(); err != nil {
+		err := cmd.Run()
+		// Unblock tarball.Write if the importer stopped reading (failed or cancelled).
+		pr.Close()
+		waitErr := grp.Wait()
+		if err != nil {
 			return fmt.Errorf("failed to load image to node %q: %w\n%s", n, err, buf.String())
 		}
-
-		if err := grp.Wait(); err != nil {
-			return fmt.Errorf("failed to write intermediate tarball representation: %w", err)
+		if waitErr != nil {
+			return fmt.Errorf("failed to write intermediate tarball representation: %w", waitErr)
 		}
 
 		return nil

--- a/pkg/publish/kind/write_test.go
+++ b/pkg/publish/kind/write_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/random"
@@ -160,6 +161,54 @@ func TestFailCommands(t *testing.T) {
 	}
 }
 
+func TestWriteClosesPipeWhenImportFailsWithoutReadingStdin(t *testing.T) {
+	ctx := context.Background()
+	// Large enough that tarball.Write fills the pipe if the importer never reads.
+	img, err := random.Image(1<<20, 3)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+
+	newTag, err := name.NewTag("kind.local/test:new")
+	if err != nil {
+		t.Fatalf("name.NewTag() = %v", err)
+	}
+
+	errTest := errors.New("import failed")
+	n1 := &fakeNode{err: errTest, skipStdin: true}
+	GetProvider = func() provider {
+		return &fakeProvider{nodes: []nodes.Node{n1}}
+	}
+
+	if err := Write(ctx, newTag, img); !errors.Is(err, errTest) {
+		t.Fatalf("Write() = %v, want %v", err, errTest)
+	}
+	if len(n1.cmds) != 1 || n1.cmds[0].stdin == nil {
+		t.Fatalf("expected import command with stdin, got %+v", n1.cmds)
+	}
+
+	// If Write returned without closing the pipe, the writer is still blocked
+	// and this Read either returns data or hangs. After the fix the pipe is
+	// closed and Read fails immediately.
+	type result struct {
+		n   int
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		n, err := n1.cmds[0].stdin.Read(make([]byte, 1))
+		ch <- result{n, err}
+	}()
+	select {
+	case got := <-ch:
+		if got.n > 0 || got.err == nil {
+			t.Fatalf("stdin still open after failed import: n=%d err=%v", got.n, got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stdin Read blocked after Write returned; pipe was not closed")
+	}
+}
+
 // fakeProvider
 type fakeProvider struct {
 	nodes []nodes.Node
@@ -170,14 +219,16 @@ func (f *fakeProvider) ListInternalNodes(string) ([]nodes.Node, error) {
 }
 
 type fakeNode struct {
-	cmds []*fakeCmd
-	err  error
+	cmds      []*fakeCmd
+	err       error
+	skipStdin bool
 }
 
 func (f *fakeNode) CommandContext(_ context.Context, cmd string, args ...string) exec.Cmd {
 	command := &fakeCmd{
-		cmd: strings.Join(append([]string{cmd}, args...), " "),
-		err: f.err,
+		cmd:       strings.Join(append([]string{cmd}, args...), " "),
+		err:       f.err,
+		skipStdin: f.skipStdin,
 	}
 	f.cmds = append(f.cmds, command)
 	return command
@@ -194,13 +245,14 @@ func (f *fakeNode) IP() (string, string, error)        { return "", "", nil }
 func (f *fakeNode) SerialLogs(io.Writer) error         { return nil }
 
 type fakeCmd struct {
-	cmd   string
-	err   error
-	stdin io.Reader
+	cmd       string
+	err       error
+	stdin     io.Reader
+	skipStdin bool
 }
 
 func (f *fakeCmd) Run() error {
-	if f.stdin != nil {
+	if f.stdin != nil && !f.skipStdin {
 		// Consume the entire stdin to move the image publish forward.
 		io.ReadAll(f.stdin)
 	}

--- a/pkg/publish/kind/write_test.go
+++ b/pkg/publish/kind/write_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/exec"
@@ -209,6 +210,28 @@ func TestWriteClosesPipeWhenImportFailsWithoutReadingStdin(t *testing.T) {
 	}
 }
 
+func TestWriteSurfacesTarballWriteError(t *testing.T) {
+	ctx := context.Background()
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+
+	newTag, err := name.NewTag("kind.local/test:new")
+	if err != nil {
+		t.Fatalf("name.NewTag() = %v", err)
+	}
+
+	errWrite := errors.New("tarball write failed")
+	GetProvider = func() provider {
+		return &fakeProvider{nodes: []nodes.Node{&fakeNode{}}}
+	}
+
+	if err := Write(ctx, newTag, failImage{Image: img, err: errWrite}); !errors.Is(err, errWrite) {
+		t.Fatalf("Write() = %v, want %v", err, errWrite)
+	}
+}
+
 // fakeProvider
 type fakeProvider struct {
 	nodes []nodes.Node
@@ -268,3 +291,13 @@ func (f *fakeCmd) SetStdin(stdin io.Reader) exec.Cmd {
 func (f *fakeCmd) SetEnv(...string) exec.Cmd    { return f }
 func (f *fakeCmd) SetStdout(io.Writer) exec.Cmd { return f }
 func (f *fakeCmd) SetStderr(io.Writer) exec.Cmd { return f }
+
+// failImage fails ConfigName so tarball.Write errors before producing a tarball.
+type failImage struct {
+	v1.Image
+	err error
+}
+
+func (f failImage) ConfigName() (v1.Hash, error) {
+	return v1.Hash{}, f.err
+}


### PR DESCRIPTION
## What

`kind.Write` streams an image tarball into `ctr images import` over an `io.Pipe`. If import fails, it returned without closing the read end or waiting on the writer goroutine. `tarball.Write` then blocked on a full pipe until process exit.

This is reachable with `KO_DOCKER_REPO=kind.local` when a node rejects the import (missing ctr, cancelled context, bad image). Library callers such as Skaffold can leak one blocked goroutine per failed load.

## Fix

Close the pipe after `cmd.Run()` and always `Wait` on the errgroup so the writer is unblocked on both success and failure.

## Test

`TestWriteClosesPipeWhenImportFailsWithoutReadingStdin` uses a large image and a fake node that fails import without reading stdin. Before the fix, a follow-up Read on the pipe either returned data or blocked. After the fix, the pipe is closed.

`go test ./pkg/publish/kind/ -count=1`

## Origin

Introduced in #180 (2020-09-04), present for 2173 days.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to kind image publish error handling and tests; no auth, data, or schema assumptions.
> 
> **Overview**
> Fixes a **goroutine leak** in `kind.Write` when `ctr images import` fails or stops reading stdin before the tarball is fully streamed.
> 
> After `cmd.Run()`, the read end of the `io.Pipe` is **closed** and the errgroup is **always waited on**, so the background `tarball.Write` goroutine is unblocked on both success and failure instead of blocking on a full pipe until process exit.
> 
> Adds **`TestWriteClosesPipeWhenImportFailsWithoutReadingStdin`** (large image + fake node that fails without consuming stdin) and extends test fakes with **`skipStdin`** to simulate that failure mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1993ca40b3ca887e3e96ab97c2943fa60142a15b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->