### PR TITLE
Honor context when loading ko.local base images

### DIFF
--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -112,7 +112,7 @@ func getBaseImage(bo *options.BuildOptions) build.GetBase {
 
 		// For ko.local, look in the daemon.
 		if ref.Context().RegistryStr() == publish.LocalDomain {
-			result, err = daemon.Image(ref)
+			result, err = daemon.Image(ref, daemon.WithContext(ctx))
 			if err != nil {
 				return nil, nil, fmt.Errorf("loading %s from daemon: %w", ref, err)
 			}

--- a/pkg/commands/config_test.go
+++ b/pkg/commands/config_test.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -55,5 +56,17 @@ func TestOverrideDefaultBaseImageUsingBuildOption(t *testing.T) {
 	gotDigest := digest.String()
 	if gotDigest != wantDigest {
 		t.Errorf("got digest %s, wanted %s", gotDigest, wantDigest)
+	}
+}
+
+func TestGetBaseImageLocalHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	bo := &options.BuildOptions{
+		BaseImage: "ko.local/does-not-exist",
+	}
+	_, _, err := getBaseImage(bo)(ctx, "ko://example.com/helloworld")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("getBaseImage() = %v, want context.Canceled", err)
 	}
 }


### PR DESCRIPTION
## What

`getBaseImage` loads `ko.local` bases with `daemon.Image(ref)` and no context. A cancelled command or stuck Docker daemon could not be interrupted. Image publish already uses `daemon.WithContext(ctx)`.

## Fix

Pass `daemon.WithContext(ctx)` so the Docker ping and image load honor the caller context.

## Test

`TestGetBaseImageLocalHonorsCanceledContext` calls `getBaseImage` with an already-cancelled context and a `ko.local` base. Before the fix the error was a Docker dial failure. After the fix it is `context.Canceled`.

`go test ./pkg/commands/ -count=1 -run TestGetBaseImageLocalHonorsCanceledContext`

## Origin

The `ko.local` daemon load was added in #1176 (2023-11-06), present for 1015 days.
