### PR TITLE
Propagate publisher Close and resolved YAML write errors

### DIFF
--- a/pkg/commands/apply.go
+++ b/pkg/commands/apply.go
@@ -62,7 +62,7 @@ func addApply(topLevel *cobra.Command) {
   # Any flags passed after '--' are passed to 'kubectl apply' directly:
   ko apply -f config -- --namespace=foo --kubeconfig=cfg.yaml
 `,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if err := options.Validate(po, bo); err != nil {
 				return fmt.Errorf("validating options: %w", err)
 			}
@@ -81,7 +81,9 @@ func addApply(topLevel *cobra.Command) {
 			if err != nil {
 				return fmt.Errorf("error creating publisher: %w", err)
 			}
-			defer publisher.Close()
+			defer func() {
+				err = closePublisher(publisher, err)
+			}()
 
 			// Issue a "kubectl apply" command reading from stdin,
 			// to which we will pipe the resolved files, and any

--- a/pkg/commands/build.go
+++ b/pkg/commands/build.go
@@ -55,7 +55,7 @@ func addBuild(topLevel *cobra.Command) {
   #   ko.local/<import path>
   # This always preserves import paths.
   ko build --local github.com/foo/bar/cmd/baz github.com/foo/bar/cmd/blah`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if err := options.Validate(po, bo); err != nil {
 				return fmt.Errorf("validating options: %w", err)
 			}
@@ -76,7 +76,9 @@ func addBuild(topLevel *cobra.Command) {
 			if err != nil {
 				return fmt.Errorf("error creating publisher: %w", err)
 			}
-			defer publisher.Close()
+			defer func() {
+				err = closePublisher(publisher, err)
+			}()
 			images, err := publishImages(ctx, args, publisher, builder)
 			if err != nil {
 				return fmt.Errorf("failed to publish images: %w", err)

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -62,7 +62,7 @@ func addCreate(topLevel *cobra.Command) {
   # Any flags passed after '--' are passed to 'kubectl apply' directly:
   ko apply -f config -- --namespace=foo --kubeconfig=cfg.yaml
 `,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if err := options.Validate(po, bo); err != nil {
 				return fmt.Errorf("validating options: %w", err)
 			}
@@ -81,7 +81,9 @@ func addCreate(topLevel *cobra.Command) {
 			if err != nil {
 				return fmt.Errorf("error creating publisher: %w", err)
 			}
-			defer publisher.Close()
+			defer func() {
+				err = closePublisher(publisher, err)
+			}()
 
 			// Issue a "kubectl create" command reading from stdin,
 			// to which we will pipe the resolved files, and any

--- a/pkg/commands/publisher.go
+++ b/pkg/commands/publisher.go
@@ -28,6 +28,18 @@ func PublishImages(ctx context.Context, importpaths []string, pub publish.Interf
 	return publishImages(ctx, importpaths, pub, b)
 }
 
+// closePublisher always closes p and returns err, unless Close fails and err
+// is nil, in which case the Close error is returned.
+func closePublisher(p publish.Interface, err error) error {
+	if p == nil {
+		return err
+	}
+	if cerr := p.Close(); cerr != nil && err == nil {
+		return cerr
+	}
+	return err
+}
+
 func publishImages(ctx context.Context, importpaths []string, pub publish.Interface, b build.Interface) (map[string]name.Reference, error) {
 	imgs := make(map[string]name.Reference)
 	for _, importpath := range importpaths {

--- a/pkg/commands/publisher_test.go
+++ b/pkg/commands/publisher_test.go
@@ -16,15 +16,58 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/ko/pkg/build"
 	"github.com/google/ko/pkg/commands/options"
+	"github.com/google/ko/pkg/publish"
 )
+
+type closeErrPublisher struct {
+	closeErr error
+	closed   bool
+}
+
+func (c *closeErrPublisher) Publish(context.Context, build.Result, string) (name.Reference, error) {
+	return nil, nil
+}
+
+func (c *closeErrPublisher) Close() error {
+	c.closed = true
+	return c.closeErr
+}
+
+var _ publish.Interface = (*closeErrPublisher)(nil)
+
+func TestClosePublisher(t *testing.T) {
+	closeErr := errors.New("close failed")
+	workErr := errors.New("publish failed")
+
+	t.Run("returns close error when work succeeded", func(t *testing.T) {
+		p := &closeErrPublisher{closeErr: closeErr}
+		if err := closePublisher(p, nil); !errors.Is(err, closeErr) {
+			t.Fatalf("closePublisher() = %v, want %v", err, closeErr)
+		}
+		if !p.closed {
+			t.Fatal("Close was not called")
+		}
+	})
+	t.Run("prefers work error over close error", func(t *testing.T) {
+		p := &closeErrPublisher{closeErr: closeErr}
+		if err := closePublisher(p, workErr); !errors.Is(err, workErr) {
+			t.Fatalf("closePublisher() = %v, want %v", err, workErr)
+		}
+		if !p.closed {
+			t.Fatal("Close was not called")
+		}
+	})
+}
 
 func TestPublishImages(t *testing.T) {
 	namespace := "base"

--- a/pkg/commands/resolve.go
+++ b/pkg/commands/resolve.go
@@ -54,7 +54,7 @@ func addResolve(topLevel *cobra.Command) {
   # This always preserves import paths.
   ko resolve --local -f config/`,
 		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			if err := options.Validate(po, bo); err != nil {
 				return fmt.Errorf("validating options: %w", err)
 			}
@@ -70,7 +70,9 @@ func addResolve(topLevel *cobra.Command) {
 			if err != nil {
 				return fmt.Errorf("error creating publisher: %w", err)
 			}
-			defer publisher.Close()
+			defer func() {
+				err = closePublisher(publisher, err)
+			}()
 			return ResolveFilesToWriter(ctx, builder, publisher, fo, so, os.Stdout)
 		},
 	}

--- a/pkg/commands/resolver.go
+++ b/pkg/commands/resolver.go
@@ -326,8 +326,12 @@ func ResolveFilesToWriter(
 	publisher publish.Interface,
 	fo *options.FilenameOptions,
 	so *options.SelectorOptions,
-	out io.WriteCloser) error {
-	defer out.Close()
+	out io.WriteCloser) (err error) {
+	defer func() {
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
 
 	// By having this as a channel, we can hook this up to a filesystem
 	// watcher and leave `fs` open to stream the names of yaml files
@@ -371,7 +375,9 @@ func ResolveFilesToWriter(
 
 			// Make a new future to use to ship the bytes back and append
 			// it to the list of futures (see comment below about ordering).
-			ch := make(resolvedFuture)
+			// Buffer one result so a send cannot block if the writer
+			// returns early (for example a broken pipe).
+			ch := make(resolvedFuture, 1)
 			futures = append(futures, ch)
 
 			// Kick off the resolution that will respond with its bytes on
@@ -405,7 +411,11 @@ func ResolveFilesToWriter(
 				// We write the delimiter LAST so that when streamed to
 				// kubectl it knows that the resource is complete and may
 				// be applied.
-				out.Write(append(b, []byte("\n---\n")...))
+				if _, err := out.Write(append(b, []byte("\n---\n")...)); err != nil {
+					// Still wait so in-flight builds are not leaked.
+					_ = errs.Wait()
+					return fmt.Errorf("writing resolved yaml: %w", err)
+				}
 			}
 		}
 	}

--- a/pkg/commands/resolver_test.go
+++ b/pkg/commands/resolver_test.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -361,6 +362,78 @@ func mustRandom() v1.Image {
 		panic(err)
 	}
 	return img
+}
+
+type errWriteCloser struct {
+	writeErr error
+	closeErr error
+	closed   bool
+}
+
+func (e *errWriteCloser) Write([]byte) (int, error) { return 0, e.writeErr }
+func (e *errWriteCloser) Close() error {
+	e.closed = true
+	return e.closeErr
+}
+
+func TestResolveFilesToWriterReturnsWriteError(t *testing.T) {
+	cache, err := build.NewCaching(testBuilder)
+	if err != nil {
+		t.Fatalf("NewCaching() = %v", err)
+	}
+	tmp := yamlToTmpFile(t, []byte(build.StrictScheme+fooRef+"\n"))
+	t.Cleanup(func() { os.Remove(tmp) })
+
+	writeErr := errors.New("write failed")
+	out := &errWriteCloser{writeErr: writeErr}
+	base := mustRepository("gcr.io/write-err")
+	err = ResolveFilesToWriter(
+		context.Background(),
+		cache,
+		kotesting.NewFixedPublish(base, testHashes),
+		&options.FilenameOptions{Filenames: []string{tmp}},
+		&options.SelectorOptions{},
+		out,
+	)
+	if !errors.Is(err, writeErr) {
+		t.Fatalf("ResolveFilesToWriter() = %v, want %v", err, writeErr)
+	}
+}
+
+func TestResolveFilesToWriterReturnsWriteErrorWithMultipleFiles(t *testing.T) {
+	cache, err := build.NewCaching(testBuilder)
+	if err != nil {
+		t.Fatalf("NewCaching() = %v", err)
+	}
+	tmp1 := yamlToTmpFile(t, []byte(build.StrictScheme+fooRef+"\n"))
+	tmp2 := yamlToTmpFile(t, []byte(build.StrictScheme+barRef+"\n"))
+	t.Cleanup(func() {
+		os.Remove(tmp1)
+		os.Remove(tmp2)
+	})
+
+	writeErr := errors.New("write failed")
+	out := &errWriteCloser{writeErr: writeErr}
+	base := mustRepository("gcr.io/write-err-multi")
+	done := make(chan error, 1)
+	go func() {
+		done <- ResolveFilesToWriter(
+			context.Background(),
+			cache,
+			kotesting.NewFixedPublish(base, testHashes),
+			&options.FilenameOptions{Filenames: []string{tmp1, tmp2}},
+			&options.SelectorOptions{},
+			out,
+		)
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, writeErr) {
+			t.Fatalf("ResolveFilesToWriter() = %v, want %v", err, writeErr)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ResolveFilesToWriter hung after a write error with multiple files")
+	}
 }
 
 func yamlToTmpFile(t *testing.T, yaml []byte) string {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -48,7 +48,7 @@ func addRun(topLevel *cobra.Command) {
 
   # You can also supply args and flags to the command.
   ko run ./cmd/baz -- -v arg1 arg2 --yes`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if err := options.Validate(po, bo); err != nil {
 				return fmt.Errorf("validating options: %w", err)
 			}
@@ -80,7 +80,9 @@ func addRun(topLevel *cobra.Command) {
 			if err != nil {
 				return fmt.Errorf("error creating publisher: %w", err)
 			}
-			defer publisher.Close()
+			defer func() {
+				err = closePublisher(publisher, err)
+			}()
 
 			if len(os.Args) < 3 {
 				return fmt.Errorf("usage: %s run <package>", os.Args[0])

--- a/pkg/publish/recorder.go
+++ b/pkg/publish/recorder.go
@@ -16,6 +16,7 @@ package publish
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -88,11 +89,9 @@ func (r *recorder) Publish(ctx context.Context, br build.Result, ref string) (na
 
 // Close implements Interface
 func (r *recorder) Close() error {
-	if err := r.inner.Close(); err != nil {
-		return err
-	}
+	var closeErr error
 	if c, ok := r.wc.(io.Closer); ok {
-		return c.Close()
+		closeErr = c.Close()
 	}
-	return nil
+	return errors.Join(r.inner.Close(), closeErr)
 }

--- a/pkg/publish/recorder_test.go
+++ b/pkg/publish/recorder_test.go
@@ -16,6 +16,7 @@ package publish
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path"
 	"strings"
@@ -103,5 +104,74 @@ func TestRecorder(t *testing.T) {
 		if want, got := repo.Context().String(), ref.Context().String(); want != got {
 			t.Errorf("reference repo = %v, wanted %v", got, want)
 		}
+	}
+}
+
+type closeTracker struct {
+	ioWriteCloser
+	closed bool
+}
+
+type ioWriteCloser interface {
+	Write([]byte) (int, error)
+	Close() error
+}
+
+func (c *closeTracker) Close() error {
+	c.closed = true
+	return c.ioWriteCloser.Close()
+}
+
+type closeErrPublish struct {
+	cbPublish
+	closeErr error
+}
+
+func (c *closeErrPublish) Close() error {
+	return c.closeErr
+}
+
+func TestRecorderCloseClosesFileWhenInnerFails(t *testing.T) {
+	repo := name.MustParseReference("docker.io/ubuntu:latest")
+	innerErr := errors.New("inner close failed")
+	inner := &closeErrPublish{
+		cbPublish: cbPublish{cb: func(_ context.Context, b build.Result, _ string) (name.Reference, error) {
+			h, err := b.Digest()
+			if err != nil {
+				return nil, err
+			}
+			return repo.Context().Digest(h.String()), nil
+		}},
+		closeErr: innerErr,
+	}
+
+	dir := t.TempDir()
+	file := path.Join(dir, "testfile")
+	recI, err := NewRecorder(inner, file)
+	if err != nil {
+		t.Fatalf("NewRecorder() = %v", err)
+	}
+	rec := recI.(*recorder)
+
+	img, err := random.Image(3, 3)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	if _, err := rec.Publish(context.Background(), signed.Image(img), ""); err != nil {
+		t.Fatalf("recorder.Publish() = %v", err)
+	}
+
+	ct := &closeTracker{ioWriteCloser: rec.wc.(interface {
+		Write([]byte) (int, error)
+		Close() error
+	})}
+	rec.wc = ct
+
+	err = rec.Close()
+	if !errors.Is(err, innerErr) {
+		t.Fatalf("Close() = %v, want %v", err, innerErr)
+	}
+	if !ct.closed {
+		t.Fatal("recorder file was not closed when inner Close failed")
 	}
 }


### PR DESCRIPTION
## What

Tarball persist happens only in `publisher.Close()`. Every command used `defer publisher.Close()`, so a failed save was logged and then discarded. `ko build --tarball=out.tar` could print a digest and exit 0.

The same `defer` hid recorder file-close errors. `ResolveFilesToWriter` ignored `Write` and `Close` errors, so a broken pipe looked like success.

This matches the user report in #562 (closed stale).

## Fix

- Named-return `defer` calls `closePublisher`, which always Closes and returns the Close error when the command otherwise succeeded.
- Recorder Closes the refs file even if the inner publisher Close fails (`errors.Join`).
- `ResolveFilesToWriter` checks Write and Close. Future channels are buffered so a Write failure cannot deadlock in-flight resolvers.

## Test

- `TestClosePublisher` (prefer work error; surface Close error on success)
- `TestRecorderCloseClosesFileWhenInnerFails`
- `TestResolveFilesToWriterReturnsWriteError`
- `TestResolveFilesToWriterReturnsWriteErrorWithMultipleFiles` (would hang without the buffered channel)

`go test ./pkg/commands/ ./pkg/publish/ -count=1 -run 'TestClosePublisher|TestRecorderClose|TestResolveFilesToWriterReturnsWriteError'`

## Origin

Tarball Close plus the "bad practice" comment landed in #134 (2020-02-19), 2371 days ago. YAML Write has discarded errors since the initial commit (2019-03-14). #540 tried to remove `Close` instead and was closed.

Ref #562
