### PR TITLE
Preserve git and digest errors instead of dropping them

### DIFF
--- a/pkg/build/cache.go
+++ b/pkg/build/cache.go
@@ -208,7 +208,7 @@ func getBuildID(ctx context.Context, file string) (string, error) {
 	cmd.Stdout = &output
 
 	if err := cmd.Run(); err != nil {
-		log.Printf("Unexpected error running \"go tool buildid %s\": %v\n%v", err, file, output.String())
+		log.Printf("Unexpected error running \"go tool buildid %s\": %v\n%v", file, err, output.String())
 		return "", fmt.Errorf("go tool buildid %s: %w", file, err)
 	}
 	return strings.TrimSpace(output.String()), nil

--- a/pkg/build/cache_test.go
+++ b/pkg/build/cache_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 ko Build Authors All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetBuildIDLogIncludesFilename(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing-binary")
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	_, err := getBuildID(context.Background(), missing)
+	if err == nil {
+		t.Fatal("getBuildID() = nil, want error for missing file")
+	}
+	got := buf.String()
+	if !strings.Contains(got, missing) {
+		t.Fatalf("log %q does not contain filename %q", got, missing)
+	}
+	// The swapped-arg bug put the exec error in the %s filename slot.
+	if strings.Contains(got, `go tool buildid exec:`) || strings.Contains(got, `go tool buildid exit status`) {
+		t.Fatalf("log put the error where the filename belongs: %q", got)
+	}
+}

--- a/pkg/build/gobuild.go
+++ b/pkg/build/gobuild.go
@@ -1499,7 +1499,10 @@ func (g *gobuild) buildAll(ctx context.Context, ref string, baseRef name.Referen
 
 	annotations := maps.Clone(g.annotations)
 	annotations[specsv1.AnnotationBaseImageName] = baseRef.Name()
-	baseDigest, _ := baseIndex.Digest()
+	baseDigest, err := baseIndex.Digest()
+	if err != nil {
+		return nil, fmt.Errorf("digesting base image index: %w", err)
+	}
 	annotations[specsv1.AnnotationBaseImageDigest] = baseDigest.String()
 
 	// Build an image for each matching platform from the base and append

--- a/pkg/internal/git/git.go
+++ b/pkg/internal/git/git.go
@@ -39,7 +39,7 @@ package git
 import (
 	"bytes"
 	"context"
-	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -69,7 +69,11 @@ func run(ctx context.Context, cfg runConfig) (string, error) {
 	err := cmd.Run()
 
 	if err != nil {
-		return "", errors.New(stderr.String())
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			return "", err
+		}
+		return "", fmt.Errorf("%w: %s", err, msg)
 	}
 
 	return stdout.String(), nil
@@ -78,9 +82,6 @@ func run(ctx context.Context, cfg runConfig) (string, error) {
 // clean the output.
 func clean(output string, err error) (string, error) {
 	output = strings.ReplaceAll(strings.Split(output, "\n")[0], "'", "")
-	if err != nil {
-		err = errors.New(strings.TrimSuffix(err.Error(), "\n"))
-	}
 	return output, err
 }
 
@@ -93,10 +94,6 @@ func cleanAllLines(output string, err error) ([]string, error) {
 			continue
 		}
 		result = append(result, l)
-	}
-	// TODO: maybe check for exec.ExitError only?
-	if err != nil {
-		err = errors.New(strings.TrimSuffix(err.Error(), "\n"))
 	}
 	return result, err
 }

--- a/pkg/internal/git/info.go
+++ b/pkg/internal/git/info.go
@@ -82,7 +82,11 @@ func GetInfo(ctx context.Context, dir string) (Info, error) {
 		return Info{}, ErrNoGit
 	}
 
-	if !isRepo(ctx, dir) {
+	ok, err := isRepo(ctx, dir)
+	if err != nil {
+		return Info{}, err
+	}
+	if !ok {
 		return Info{}, ErrNotRepository
 	}
 
@@ -129,12 +133,18 @@ func GetInfo(ctx context.Context, dir string) (Info, error) {
 }
 
 // isRepo returns true if current folder is a git repository.
-func isRepo(ctx context.Context, dir string) bool {
+func isRepo(ctx context.Context, dir string) (bool, error) {
 	out, err := run(ctx, runConfig{
 		dir:  dir,
 		args: []string{"rev-parse", "--is-inside-work-tree"},
 	})
-	return err == nil && strings.TrimSpace(out) == "true"
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return false, err
+		}
+		return false, nil
+	}
+	return strings.TrimSpace(out) == "true", nil
 }
 
 // checkDirty returns an error if the current git repository is dirty.
@@ -143,7 +153,13 @@ func checkDirty(ctx context.Context, dir string) error {
 		dir:  dir,
 		args: []string{"status", "--porcelain"},
 	})
-	if strings.TrimSpace(out) != "" || err != nil {
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		return ErrDirty{status: out}
+	}
+	if strings.TrimSpace(out) != "" {
 		return ErrDirty{status: out}
 	}
 	return nil

--- a/pkg/internal/git/info_test.go
+++ b/pkg/internal/git/info_test.go
@@ -49,6 +49,15 @@ import (
 
 const fakeGitURL = "git@github.com:foo/bar.git"
 
+func TestGetInfoCanceledContext(t *testing.T) {
+	dir := t.TempDir()
+	gittesting.GitInit(t, dir)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := git.GetInfo(ctx, dir)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestNotAGitFolder(t *testing.T) {
 	dir := t.TempDir()
 	i, err := git.GetInfo(context.TODO(), dir)


### PR DESCRIPTION
## What

Three small error-handling bugs:

1. `git run()` replaced the exec error with `errors.New(stderr)`. A cancelled context or missing stderr became an empty error. `GetInfo` then treated cancel as "not a git repository".
2. `go tool buildid` logged `err` in the filename slot, so the message showed `go tool buildid exit status 1` instead of the path.
3. The multi-arch path discarded `baseIndex.Digest()` and wrote a zero hash into `org.opencontainers.image.base.digest`. The single-platform path already returns that error.

## Fix

Wrap git failures as `fmt.Errorf("%w: %s", err, stderr)` (or return `err` when stderr is empty). Propagate `context.Canceled` / `DeadlineExceeded` from `isRepo` and `checkDirty`. Swap the buildid log arguments. Return the Digest() error on the multi-arch path.

## Test

- `TestGetInfoCanceledContext` (`errors.Is(err, context.Canceled)`)
- `TestGetBuildIDLogIncludesFilename` (log contains the path, not `go tool buildid exit status`)
- Existing `TestNotAGitFolder` still expects `ErrNotRepository`
- Existing `TestGoBuildIndex` still passes

`go test ./pkg/internal/git/ ./pkg/build/ -count=1`

## Origin

Git wrapper: #1307 (2024-05-11). Buildid log: #269 (2021-12-08). Index digest discard: #1426 (2024-10-15).
