### PR TITLE
docs: expand debugging guide for remote attach

### DIFF
--- a/docs/features/debugging.md
+++ b/docs/features/debugging.md
@@ -20,10 +20,30 @@ Build the image using the debug feature.
 ko build . --debug
 ```
 
+You can also pass `--debug` to `ko apply` or `ko resolve` so Kubernetes manifests point at a debug-enabled image.
+
 Run the container, ensuring that the debug port (`40000`) is exposed to allow clients to connect to it.
 
 ```plaintext
 docker run -p 40000:40000 <img>
 ```
 
-This sets up your app to be waiting to run the command you've specified. All that's needed now is to connect your debugger client to the running container!
+On Kubernetes, publish port `40000` from the Pod and forward it locally:
+
+```plaintext
+kubectl port-forward deploy/<your-deployment> 40000:40000
+```
+
+The process waits for a debugger client before your program runs. Connect with the [delve](https://github.com/go-delve/delve) CLI:
+
+```plaintext
+dlv connect 127.0.0.1:40000
+```
+
+Or use an editor that speaks the Delve remote protocol (for example VS Code `connect` / `request: attach` to `127.0.0.1:40000`).
+
+### Tips
+
+- Prefer a base image that includes a shell and basic tools if you also need to `kubectl exec` into the container while debugging.
+- Debug builds keep symbols and skip optimizations that would make stepping through code harder. Do not ship `--debug` images to production.
+- Remote debugging tools that inject agents into Pods (for example older workflows based on Squash) still need a writable container filesystem and often a non-distroless base image. The built-in `--debug` path above is the supported ko-native approach.


### PR DESCRIPTION
## Summary
Expand the debugging guide with remote attach steps.

Covers port-forward on Kubernetes, connecting with `dlv connect`, editor attach, and notes on base images for remote debug workflows.

Fixes #78